### PR TITLE
[WIP] Make it easier to write tests for WordPress plugins containing CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 2. Add the required test scripts to the `composer.json` file:
 	```json
 	"scripts": {
-        "behat": "run-behat-tests",
-        "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
         "phpunit": "run-php-unit-tests",
+        "behat": "run-behat-tests",
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",
@@ -52,7 +51,7 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 	```
 	This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
 
-5. Update your composer dependencies and regenerate your autoloader and binary folders:
+4. Update your composer dependencies and regenerate your autoloader and binary folders:
 	```bash
 	composer update
 	```
@@ -80,72 +79,6 @@ composer behat -- features/cli-info.feature
 Prepending with the double dash is needed because the arguments would otherwise be sent to Composer itself, not the tool that Composer executes.
 
 ### Controlling the test environment
-
-#### WordPress Version
-
-You can run the tests against a specific version of WordPress by setting the `WP_VERSION` environment variable.
-
-This variable understands any numeric version, as well as the special terms `latest` and `trunk`.
-
-Note: This only applies to the Behat functional tests. All other tests never load WordPress.
-
-Here's how to run your tests against the latest trunk version of WordPress:
-```bash
-WP_VERSION=trunk composer behat
-```
-
-#### WP-CLI Binary
-
-You can run the tests against a specific WP-CLI binary, instead of using the one that has been built in your project's `vendor/bin` folder.
-
-This can be useful to run your tests against a specific Phar version of WP_CLI.
-
-To do this, you can set the `WP_CLI_BIN_DIR` environment variable to point to a folder that contains an executable `wp` binary. Note: the binary has to be named `wp` to be properly recognized.
-
-As an example, here's how to run your tests against a specific Phar version you've downloaded.
-```bash
-# Prepare the binary you've downloaded into the ~/wp-cli folder first.
-mv ~/wp-cli/wp-cli-1.2.0.phar ~/wp-cli/wp
-chmod +x ~/wp-cli/wp
-
-WP_CLI_BIN_DIR=~/wp-cli composer behat
-```
-
-### Setting up the tests in Travis CI
-
-Basic rules for setting up the test framework with Travis CI:
-
-* `composer prepare-tests` needs to be called once per environment.
-* `linting and sniffing` is a static analysis, so it shouldn't depend on any specific environment. You should do this only once, as a separate stage, instead of per environment.
-* `composer behat || composer behat-rerun` causes the Behat tests to run in their entirety first, and in case their were failed scenarios, a second run is done with only the failed scenarios. This usually gets around intermittent issues like timeouts or similar.
-
-Here's a basic setup of how you can configure Travis CI to work with the test framework (extract):
-```yml
-install:
-  - composer install
-  - composer prepare-tests
-
-script:
-  - composer phpunit
-  - composer behat || composer behat-rerun
-
-jobs:
-  include:
-    - stage: sniff
-      script:
-        - composer lint
-        - composer phpcs
-      env: BUILD=sniff
-    - stage: test
-      php: 7.2
-      env: WP_VERSION=latest
-    - stage: test
-      php: 7.2
-      env: WP_VERSION=3.7.11
-    - stage: test
-      php: 7.2
-      env: WP_VERSION=trunk
-```
 
 #### WP-CLI version
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 2. Add the required test scripts to the `composer.json` file:
 	```json
 	"scripts": {
+        "behat": "run-behat-tests",
+        "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
         "phpunit": "run-php-unit-tests",
-        "behat": "run-behat-tests",
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",
@@ -51,7 +52,7 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 	```
 	This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
 
-4. Update your composer dependencies and regenerate your autoloader and binary folders:
+5. Update your composer dependencies and regenerate your autoloader and binary folders:
 	```bash
 	composer update
 	```
@@ -79,6 +80,72 @@ composer behat -- features/cli-info.feature
 Prepending with the double dash is needed because the arguments would otherwise be sent to Composer itself, not the tool that Composer executes.
 
 ### Controlling the test environment
+
+#### WordPress Version
+
+You can run the tests against a specific version of WordPress by setting the `WP_VERSION` environment variable.
+
+This variable understands any numeric version, as well as the special terms `latest` and `trunk`.
+
+Note: This only applies to the Behat functional tests. All other tests never load WordPress.
+
+Here's how to run your tests against the latest trunk version of WordPress:
+```bash
+WP_VERSION=trunk composer behat
+```
+
+#### WP-CLI Binary
+
+You can run the tests against a specific WP-CLI binary, instead of using the one that has been built in your project's `vendor/bin` folder.
+
+This can be useful to run your tests against a specific Phar version of WP_CLI.
+
+To do this, you can set the `WP_CLI_BIN_DIR` environment variable to point to a folder that contains an executable `wp` binary. Note: the binary has to be named `wp` to be properly recognized.
+
+As an example, here's how to run your tests against a specific Phar version you've downloaded.
+```bash
+# Prepare the binary you've downloaded into the ~/wp-cli folder first.
+mv ~/wp-cli/wp-cli-1.2.0.phar ~/wp-cli/wp
+chmod +x ~/wp-cli/wp
+
+WP_CLI_BIN_DIR=~/wp-cli composer behat
+```
+
+### Setting up the tests in Travis CI
+
+Basic rules for setting up the test framework with Travis CI:
+
+* `composer prepare-tests` needs to be called once per environment.
+* `linting and sniffing` is a static analysis, so it shouldn't depend on any specific environment. You should do this only once, as a separate stage, instead of per environment.
+* `composer behat || composer behat-rerun` causes the Behat tests to run in their entirety first, and in case their were failed scenarios, a second run is done with only the failed scenarios. This usually gets around intermittent issues like timeouts or similar.
+
+Here's a basic setup of how you can configure Travis CI to work with the test framework (extract):
+```yml
+install:
+  - composer install
+  - composer prepare-tests
+
+script:
+  - composer phpunit
+  - composer behat || composer behat-rerun
+
+jobs:
+  include:
+    - stage: sniff
+      script:
+        - composer lint
+        - composer phpcs
+      env: BUILD=sniff
+    - stage: test
+      php: 7.2
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.2
+      env: WP_VERSION=3.7.11
+    - stage: test
+      php: 7.2
+      env: WP_VERSION=trunk
+```
 
 #### WP-CLI version
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -210,8 +210,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$variables = [
 			'FRAMEWORK_ROOT' => realpath( $framework_root ),
-			'SRC_DIR'        => realpath( dirname(  __DIR__, 2 ) ),
-			'PROJECT_DIR'    => realpath( dirname(  __DIR__, 5 ) ),
+			'SRC_DIR'        => realpath( dirname( dirname(  __DIR__ ) ) ),
+			'PROJECT_DIR'    => realpath( dirname( dirname( dirname( dirname( dirname(  __DIR__ ) ) ) ) ) ),
 		];
 
 		return $variables;

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -209,8 +209,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		$variables = [
-			'SRC_DIR'        => realpath( dirname( dirname( __DIR__ ) ) ),
 			'FRAMEWORK_ROOT' => realpath( $framework_root ),
+			'SRC_DIR'        => realpath( dirname(  __DIR__, 2 ) ),
+			'PROJECT_DIR'    => realpath( dirname(  __DIR__, 5 ) ),
 		];
 
 		return $variables;

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -134,6 +134,8 @@ $steps->Given(
 	'/^these installed and active plugins:$/',
 	function( $world, $stream ) {
 		$plugins = implode( ' ', array_map( 'trim', explode( PHP_EOL, (string) $stream ) ) );
+		$plugins = $world->replace_variables( $plugins );
+
 		$world->proc( "wp plugin install $plugins --activate" )->run_check();
 	}
 );


### PR DESCRIPTION
Situation:

I'm developing a WordPress plugin that registers some WP-CLI commands. Now I want to write some functional tests for these, ideally by leveraging this identical testing framework as for standalone commands.

In case anyone's wondering, the plugin I'm developing can be found at https://github.com/wearerequired/traduttore.

To run the tests, I need to activate / load the plugin somehow.

One suggestion by Daniel that led me to the right path was creating a ZIP archive and installing that ZIP file. He did this in a plugin once where `FeatureContext.php` was part of the code base. I obviously can't edit that file because it's now in the `wp-cli-tests` package.

Alain's suggestion was to use something like this:

```gherkin
Feature: Testing a custom plugin

  Background:
    Given a WP installation
    And these installed and active plugins:
    """
    {RUN_DIR}/packaged_plugin.zip
    """
```

However, variables are currently **not** being replaced in the `these installed and active plugins` step.

Plus, `RUN_DIR` points to the WordPress directory used for the tests, not the actual repository where my plugin and my ZIP file reside.

Thus, I decided to add a new variable, `PROJECT_DIR` which aims to be the plugin source directory. That's also where `wp-cli/wp-cli-tests` is installed using Composer in `PROJECT_DIR/vendor/wp-cli/wp-cli-tests`.

This way I can use the following scenario:

```gherkin
Feature: Testing a custom plugin

  Background:
    Given a WP installation
    And these installed and active plugins:
    """
    {PROJECT_DIR}/packaged_plugin.zip
    """
```