### PR TITLE
PHPCompatibilityWP: update to use version ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpcompatibility/phpcompatibility-wp": "^1",
+        "phpcompatibility/phpcompatibility-wp": "^2",
         "phpunit/phpunit": ">=4.8 <7",
         "roave/security-advisories": "dev-master",
         "wp-cli/config-command": "^1 || ^2",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,10 +26,10 @@
 		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP">
 		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
-		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
+		<exclude name="PHPCompatibility.Functions.NewFunctions.array_columnFound"/>
 		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
+		<exclude name="PHPCompatibility.IniDirectives.RemovedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
+		<exclude name="PHPCompatibility.IniDirectives.RemovedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
 	</rule>
 
 	<!-- For help in understanding this testVersion:


### PR DESCRIPTION
... which includes PHPCompatibility 9.0 and lots of new sniffs.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.0.0
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0

