### PR TITLE
PHPCS: fix up the code base [1] - whitespace

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -210,8 +210,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$variables = [
 			'FRAMEWORK_ROOT' => realpath( $framework_root ),
-			'SRC_DIR'        => realpath( dirname( dirname(  __DIR__ ) ) ),
-			'PROJECT_DIR'    => realpath( dirname( dirname( dirname( dirname( dirname(  __DIR__ ) ) ) ) ) ),
+			'SRC_DIR'        => realpath( dirname( dirname( __DIR__ ) ) ),
+			'PROJECT_DIR'    => realpath( dirname( dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) ) ),
 		];
 
 		return $variables;
@@ -531,7 +531,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 */
 	public function create_run_dir() {
 		if ( ! isset( $this->variables['RUN_DIR'] ) ) {
-			self::$run_dir = $this->variables['RUN_DIR'] = sys_get_temp_dir() . '/' . uniqid( 'wp-cli-test-run-' . self::$temp_dir_infix . '-', true );
+			self::$run_dir              = sys_get_temp_dir() . '/' . uniqid( 'wp-cli-test-run-' . self::$temp_dir_infix . '-', true );
+			$this->variables['RUN_DIR'] = self::$run_dir;
 			mkdir( $this->variables['RUN_DIR'] );
 		}
 	}

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -73,7 +73,8 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		$behat_tags = dirname( __DIR__ ) . '/utils/behat-tags.php';
 
 		$php_version = substr( PHP_VERSION, 0, 3 );
-		$contents    = $expected = '';
+		$contents    = '';
+		$expected    = '';
 
 		if ( '5.3' === $php_version ) {
 			$contents = '@require-php-5.2 @require-php-5.3 @require-php-5.4 @less-than-php-5.2 @less-than-php-5.3 @less-than-php-5.4';

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -44,7 +44,7 @@ $wp_version_reqs = array();
 // Only apply @require-wp tags when WP_VERSION isn't 'latest', 'nightly' or 'trunk'.
 // 'latest', 'nightly' and 'trunk' are expected to work with all features.
 if ( $wp_version &&
-     ! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
 	$wp_version_reqs = array_merge(
 		version_tags( 'require-wp', $wp_version, '<', $features_folder ),
 		version_tags( 'less-than-wp', $wp_version, '>=', $features_folder )


### PR DESCRIPTION
Fixes relate to the following rules:
* No multiple assignments in one statement.
* One space on the inside of open/close parenthesis when there is content between them.
* Use tabs for indentation, spaces for inline alignment.
* No precision alignment.