### PR TITLE
PHPCS: fix up the code base [2] - object instantiation

### DIFF
--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -48,7 +48,7 @@ class Process {
 	 * @return Process
 	 */
 	public static function create( $command, $cwd = null, $env = array() ) {
-		$proc = new self;
+		$proc = new self();
 
 		$proc->command = $command;
 		$proc->cwd     = $cwd;

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -515,7 +515,7 @@ function mustache_render( $template_name, $data = array() ) {
  */
 function make_progress_bar( $message, $count, $interval = 100 ) {
 	if ( \cli\Shell::isPiped() ) {
-		return new \WP_CLI\NoOp;
+		return new \WP_CLI\NoOp();
 	}
 
 	return new \cli\progress\Bar( $message, $count, $interval );


### PR DESCRIPTION
Fixes relate to the following rules:
* Always use parenthesis when instantiating a new object.