### PR TITLE
PHPCS: fix up the code base [4] - strict comparisons

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -356,7 +356,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				$parent = $matches[1];
 				$child  = $matches[2];
 
-				if ( $parent == $master_pid ) {
+				if ( $parent === $master_pid ) {
 					self::terminate_proc( $child );
 				}
 			}

--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -61,7 +61,7 @@ function checkString( $output, $expected, $action, $message = false ) {
 
 function compareTables( $expected_rows, $actual_rows, $output ) {
 	// the first row is the header and must be present
-	if ( $expected_rows[0] != $actual_rows[0] ) {
+	if ( $expected_rows[0] !== $actual_rows[0] ) {
 		throw new \Exception( $output );
 	}
 
@@ -75,7 +75,7 @@ function compareTables( $expected_rows, $actual_rows, $output ) {
 }
 
 function compareContents( $expected, $actual ) {
-	if ( gettype( $expected ) != gettype( $actual ) ) {
+	if ( gettype( $expected ) !== gettype( $actual ) ) {
 		return false;
 	}
 
@@ -168,12 +168,12 @@ function checkThatCsvStringContainsValues( $actualCSV, $expectedCSV ) {
 		$expected_row = array_combine( $expectedHeaders, $expected_row );
 		foreach ( $actualCSV as $actual_row ) {
 
-			if ( count( $actualHeaders ) != count( $actual_row ) ) {
+			if ( count( $actualHeaders ) !== count( $actual_row ) ) {
 				continue;
 			}
 
 			$actual_row = array_intersect_key( array_combine( $actualHeaders, $actual_row ), $expected_row );
-			if ( $actual_row == $expected_row ) {
+			if ( $actual_row === $expected_row ) {
 				$expectedResult++;
 			}
 		}

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -411,7 +411,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 	$assoc_args = array();
 
 	$host_parts = explode( ':', $raw_host );
-	if ( count( $host_parts ) == 2 ) {
+	if ( count( $host_parts ) === 2 ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;
 		$extra                              = trim( $extra );
 		if ( is_numeric( $extra ) ) {

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -70,7 +70,7 @@ $steps->Then(
 			$expected_rows[] = $world->replace_variables( implode( "\t", $row ) );
 		}
 
-		$start = array_search( $expected_rows[0], $actual_rows );
+		$start = array_search( $expected_rows[0], $actual_rows, true );
 
 		if ( false === $start ) {
 			throw new \Exception( $world->result );
@@ -183,9 +183,9 @@ $steps->Then(
 			$path = $world->variables['RUN_DIR'] . "/$path";
 		}
 
-		if ( 'file' == $type ) {
+		if ( 'file' === $type ) {
 			$test = 'file_exists';
-		} elseif ( 'directory' == $type ) {
+		} elseif ( 'directory' === $type ) {
 			$test = 'is_dir';
 		}
 
@@ -206,9 +206,9 @@ $steps->Then(
 				}
 				$action   = substr( $action, 0, -1 );
 				$expected = $world->replace_variables( (string) $expected );
-				if ( 'file' == $type ) {
+				if ( 'file' === $type ) {
 					$contents = file_get_contents( $path );
-				} elseif ( 'directory' == $type ) {
+				} elseif ( 'directory' === $type ) {
 					$files = glob( rtrim( $path, '/' ) . '/*' );
 					foreach ( $files as &$file ) {
 						$file = str_replace( $path . '/', '', $file );


### PR DESCRIPTION
Fixes relate to the following rules:
* Use strict comparisons.
* Use the `$strict` parameter when calling `in_array()`.