### PR TITLE
PHPCS: fix up the code base [6] - multi-line function calls

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -457,9 +457,11 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 
 		$str = preg_replace_callback(
-			'/{INVOKE_WP_CLI_WITH_PHP_ARGS-([^}]*)}/', function ( $matches ) use ( $phar_path, $shell_path ) {
+			'/{INVOKE_WP_CLI_WITH_PHP_ARGS-([^}]*)}/',
+			function ( $matches ) use ( $phar_path, $shell_path ) {
 				return $phar_path ? "php {$matches[1]} {$phar_path}" : ( 'WP_CLI_PHP_ARGS=' . escapeshellarg( $matches[1] ) . ' ' . $shell_path );
-			}, $str
+			},
+			$str
 		);
 
 		return $str;
@@ -994,7 +996,14 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$log .= sprintf(
 			PHP_EOL . "Total process run time %s (tests %s, overhead %.3f %d%%), calls %d (%d unique) for '%s' run from '%s'" . PHP_EOL,
-			$fmt( $ptime ), $fmt( $time ), $overhead, $pct, $calls, $unique, $suite, $run_from
+			$fmt( $ptime ),
+			$fmt( $time ),
+			$overhead,
+			$pct,
+			$calls,
+			$unique,
+			$suite,
+			$run_from
 		);
 
 		uasort(

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -917,7 +917,8 @@ function parse_str_to_argv( $arguments ) {
 				}
 			}
 				return $arg;
-		}, $argv
+		},
+		$argv
 	);
 	return $argv;
 }

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -122,7 +122,8 @@ $steps->Given(
 		$world->install_wp();
 		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
 		$world->proc(
-			'wp core install-network', array(
+			'wp core install-network',
+			array(
 				'title'      => 'WP CLI Network',
 				'subdomains' => $subdomains,
 			)

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -242,7 +242,8 @@ $steps->Then(
 );
 
 $steps->Then(
-	'/^an email should (be sent|not be sent)$/', function( $world, $expected ) {
+	'/^an email should (be sent|not be sent)$/',
+	function( $world, $expected ) {
 		if ( 'be sent' === $expected ) {
 			assertNotEquals( 0, $world->email_sends );
 		} elseif ( 'not be sent' === $expected ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,20 +1,23 @@
 <?php
 define( 'WP_CLI', true );
 define( 'WP_CLI_TESTS_ROOT', dirname( __DIR__ ) );
-define( 'VENDOR_DIR',
+define(
+	'VENDOR_DIR',
 	file_exists( WP_CLI_TESTS_ROOT . '/vendor/autoload.php' )
 		? WP_CLI_TESTS_ROOT . '/vendor'
 		: WP_CLI_TESTS_ROOT . '/../..'
 );
 define( 'PACKAGE_ROOT', VENDOR_DIR . '/..' );
 
-define( 'WP_CLI_ROOT',
+define(
+	'WP_CLI_ROOT',
 	is_readable( PACKAGE_ROOT . '/VERSION' )
 		? PACKAGE_ROOT
 		: VENDOR_DIR . '/wp-cli/wp-cli'
 );
 
-define( 'WP_CLI_VERSION',
+define(
+	'WP_CLI_VERSION',
 	is_readable( WP_CLI_ROOT . '/VERSION' )
 		? trim( file_get_contents( WP_CLI_ROOT . '/VERSION' ) )
 		: '2.x.x'

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -23,8 +23,10 @@ function version_tags(
 		return array();
 	}
 
-	exec( "grep '@{$prefix}-[0-9\.]*' -h -o {$features_folder}/*.feature | uniq",
-		$existing_tags );
+	exec(
+		"grep '@{$prefix}-[0-9\.]*' -h -o {$features_folder}/*.feature | uniq",
+		$existing_tags
+	);
 
 	$skip_tags = array();
 
@@ -51,14 +53,15 @@ if ( $wp_version &&
 	);
 } else {
 	// But make sure @less-than-wp tags always exist for those special cases. (Note: @less-than-wp-latest etc won't work and shouldn't be used).
-	$wp_version_reqs = array_merge( $wp_version_reqs,
-		version_tags( 'less-than-wp', '9999', '>=', $features_folder ) );
+	$wp_version_reqs = array_merge(
+		$wp_version_reqs,
+		version_tags( 'less-than-wp', '9999', '>=', $features_folder )
+	);
 }
 
 $skip_tags = array_merge(
 	$wp_version_reqs,
 	version_tags( 'require-php', PHP_VERSION, '<', $features_folder ),
-
 	// Note: this was '>' prior to WP-CLI 1.5.0 but the change is unlikely to
 	// cause BC issues as usually compared against major.minor only.
 	version_tags( 'less-than-php', PHP_VERSION, '>=', $features_folder )


### PR DESCRIPTION
Fixes relate to the following rules:
* Each argument in a multiline function call should start on a new line.

Note: in the (near?) future, multi-line arguments in function calls will also be  prohibited.
This will impact (some of) this code.

The choice for the future is:
* Either change the closures to full-blown methods.
* Declare them before the function call, assign them to a variable and pass the  variable to the function call.