### PR TITLE
Create a `WP_CLI_CS` standard for PHP_CodeSniffer

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ vendor/
 *.txt
 *.log
 composer.lock
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -41,7 +41,38 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 	```
 	This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
 
-5. Update your composer dependencies and regenerate your autoloader and binary folders:
+5. Optionally add a `phpcs.xml.dist` file to the package root to enable code style and best practice checks using PHP_CodeSniffer.
+
+    Example of a minimal custom ruleset based on the defaults set in the WP-CLI testing framework:
+    ```xml
+    <?xml version="1.0"?>
+    <ruleset name="WP-CLI-PROJECT-NAME">
+    <description>Custom ruleset for WP-CLI PROJECT NAME</description>
+
+        <!-- What to scan. -->
+        <file>.</file>
+
+        <!-- Show progress. -->
+        <arg value="p"/>
+
+        <!-- Strip the filepaths down to the relevant bit. -->
+        <arg name="basepath" value="./"/>
+
+        <!-- Check up to 8 files simultaneously. -->
+        <arg name="parallel" value="8"/>
+
+        <!-- For help understanding the `testVersion` configuration setting:
+             https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+        <config name="testVersion" value="5.4-"/>
+
+        <!-- Rules: Include the base ruleset for WP-CLI projects. -->
+        <rule ref="WP_CLI_CS"/>
+
+    </ruleset>
+    ```
+
+    All other [PHPCS configuration options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
+6. Update your composer dependencies and regenerate your autoloader and binary folders:
 	```bash
 	composer update
 	```

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -1,13 +1,13 @@
 To make use of the WP-CLI testing framework, you need to complete the following steps from within the package you want to add them to:
 
 1. Add the testing framework as a development requirement:
-	```bash
-	composer require --dev wp-cli/wp-cli-tests
-	```
+    ```bash
+    composer require --dev wp-cli/wp-cli-tests
+    ```
 
 2. Add the required test scripts to the `composer.json` file:
-	```json
-	"scripts": {
+    ```json
+    "scripts": {
         "behat": "run-behat-tests",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
@@ -20,26 +20,26 @@ To make use of the WP-CLI testing framework, you need to complete the following 
             "@phpunit",
             "@behat"
         ]
-	}
-	```
-	You can of course remove the ones you don't need.
+    }
+    ```
+    You can of course remove the ones you don't need.
 
 3. Optionally add a modified process timeout to the `composer.json` file to make sure scripts can run until their work is completed:
-	```json
-	"config": {
-		"process-timeout": 1800
-	},
-	```
-	The timeout is expressed in seconds.
+    ```json
+    "config": {
+        "process-timeout": 1800
+    },
+    ```
+    The timeout is expressed in seconds.
 
 4. Optionally add a `behat.yml` file to the package root with the following content:
-	```json
-	default:
-	  paths:
-	    features: features
+    ```json
+    default:
+      paths:
+        features: features
         bootstrap: vendor/wp-cli/wp-cli-tests/features/bootstrap
-	```
-	This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
+    ```
+    This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
 
 5. Optionally add a `phpcs.xml.dist` file to the package root to enable code style and best practice checks using PHP_CodeSniffer.
 
@@ -73,9 +73,9 @@ To make use of the WP-CLI testing framework, you need to complete the following 
 
     All other [PHPCS configuration options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
 6. Update your composer dependencies and regenerate your autoloader and binary folders:
-	```bash
-	composer update
-	```
+    ```bash
+    composer update
+    ```
 
 You are now ready to use the testing framework from within your package.
 

--- a/WP_CLI_CS/ruleset.xml
+++ b/WP_CLI_CS/ruleset.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WP_CLI_CS" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+	<description>Coding standard for WP-CLI projects</description>
+
+	<!--
+	To include this ruleset in a WP-CLI project, use `rule ref="WP_CLI_CS"` in brackets.
+	See the instructions in the README/USING for an example.
+
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	-->
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	#############################################################################
+	-->
+
+	<!-- Ignoring select files/folders for all projects.
+		 https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>*/.git/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+
+	<!--
+	#############################################################################
+	USE THE PHPCOMPATIBILITY RULESET
+
+	This checks code for PHP cross-version compatibility.
+	See: https://github.com/PHPCompatibility/PHPCompatibility
+	#############################################################################
+	-->
+
+	<rule ref="PHPCompatibility">
+		<!-- Only scan PHP files for PHP compatibility. -->
+		<include-pattern>*\.php$</include-pattern>
+
+		<!-- Polyfill package is included with WP-CLI, so available to all projects. -->
+		<exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_columnFound"/>
+	</rule>
+
+	<!--
+	#############################################################################
+	USE THE WORDPRESS-EXTRA RULESET
+
+	This checks code against the WordPress Core code style requirements, as well as
+	a number of modern PHP style rules and other best practices which are
+	currently not yet covered in the Core style handbook.
+	See: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+	See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+	#############################################################################
+	-->
+
+	<rule ref="WordPress-Extra">
+
+		<!-- No need for this sniff as the parallel linter command takes care of linting. -->
+		<exclude name="Generic.PHP.Syntax"/>
+
+		<!-- To make autoloading easier, PSR-4 is mostly adhered to for file naming. -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- Output is sent to cli, not to HTML, so this sniff is not applicable to WP-CLI.
+			 Note: some output escaping may still be needed/beneficial, however this would probably
+			 require a custom sniff. -->
+		<exclude name="WordPress.Security.EscapeOutput"/>
+
+		<!-- WP-CLI is intended as a developer tool, so using development functions should be fine. -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions"/>
+
+		<!-- Make some allowance for the fact that the code will be run in a command-line environment. -->
+		<exclude name="Generic.PHP.BacktickOperator"/>
+
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI"/><!-- Namespaces and non-namespaced classes. -->
+				<element value="wpcli"/><!-- Global variables and functions. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Allow for silencing errors in combination with a select list of functions.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#error-silencing-use-build-in-function-whitelist -->
+	<rule ref="WordPress.PHP.NoSilencedErrors">
+		<properties>
+			<property name="use_default_whitelist" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- Make some allowance for the fact that the code will be run in a command-line environment.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#excluding-a-group-of-checks -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="runtime_configuration"/>
+				<element value="system_calls"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="curl"/>
+				<element value="file_get_contents"/>
+				<element value="file_system_read"/>
+				<!-- As PHP 5.4. is the minimum for most projects, using json_encode() is fine. -->
+				<element value="json_encode"/>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Run the unit tests, if they exist
-if [ -f "phpcs.xml" ] || [ -f "phpcs.xml.dist" ] || [ -f ".phpcs.xml" ] || [ -f ".phpcs.xml.dist" ]
+# Run the code style check only if a configuration file exists.
+if [ -f ".phpcs.xml" ] || [ -f "phpcs.xml" ] || [ -f ".phpcs.xml.dist" ] || [ -f "phpcs.xml.dist" ]
 then
 	vendor/bin/phpcs "$@"
 fi

--- a/composer.json
+++ b/composer.json
@@ -7,20 +7,21 @@
     ],
     "homepage": "https://wp-cli.org",
     "license": "MIT",
+    "type" : "phpcodesniffer-standard",
     "require": {
         "php": ">=5.4",
         "behat/behat": "^2.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpcompatibility/phpcompatibility-wp": "^2",
+        "phpcompatibility/php-compatibility": "^9",
         "phpunit/phpunit": ">=4.8 <7",
         "roave/security-advisories": "dev-master",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",
         "wp-cli/wp-cli": "^2",
-        "wp-coding-standards/wpcs": "^1"
+        "wp-coding-standards/wpcs": "^2.1"
     },
     "require-dev": {
         "wp-cli/regenerate-readme": "^2"

--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -16,12 +16,14 @@ function assert_regex( $regex, $actual ) {
 }
 
 function assert_equals( $expected, $actual ) {
+	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Deliberate loose comparison.
 	if ( $expected != $actual ) {
 		throw new Exception( 'Actual value: ' . var_export( $actual, true ) );
 	}
 }
 
 function assert_not_equals( $expected, $actual ) {
+	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Deliberate loose comparison.
 	if ( $expected == $actual ) {
 		throw new Exception( 'Actual value: ' . var_export( $actual, true ) );
 	}

--- a/features/extra/no-mail.php
+++ b/features/extra/no-mail.php
@@ -1,12 +1,18 @@
 <?php
-
-/*
+/**
  * This file is copied as amu-plugin into new WP installs to reroute normal
  * mails into log entries.
  */
 
+/**
+ * Replace WP native pluggable wp_mail function for test purposes.
+ *
+ * @param string $to Email address.
+ *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WP native function.
+ */
 function wp_mail( $to ) {
 	// Log for testing purposes
 	WP_CLI::log( "WP-CLI test suite: Sent email to {$to}." );
 }
-
+// phpcs:enable

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,56 +1,73 @@
 <?xml version="1.0"?>
-<ruleset name="WP-CLI">
-	<description>Custom ruleset for WP-CLI</description>
+<ruleset name="WP-CLI-tests">
+	<description>Custom ruleset for WP-CLI-tests</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
 
-	<!-- What to scan -->
+	<!-- What to scan. -->
 	<file>.</file>
-	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
-	<exclude-pattern>*/.git/*</exclude-pattern>
-	<exclude-pattern>*/ci/*</exclude-pattern>
-	<exclude-pattern>*/features/*</exclude-pattern>
-	<exclude-pattern>*/packages/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/utils/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!-- How to scan -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="colors"/> <!-- Show results with colors -->
-	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
+	<!-- Show progress. -->
+	<arg value="p"/>
 
-	<!-- Rules: Check PHP version compatibility - see
-		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
-	<rule ref="PHPCompatibilityWP">
-		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
-		<exclude name="PHPCompatibility.Functions.NewFunctions.array_columnFound"/>
-		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
-		<exclude name="PHPCompatibility.IniDirectives.RemovedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
-		<exclude name="PHPCompatibility.IniDirectives.RemovedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
-	</rule>
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
 
-	<!-- For help in understanding this testVersion:
-		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
 
-	<!-- Rules: WordPress Coding Standards - see
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<rule ref="WordPress-Core">
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
-	</rule>
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
 
-	<!-- For help in understanding these custom sniff properties:
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<rule ref="WordPress.Files.FileName">
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="strict_class_file_names" value="false"/>
+			<property name="prefixes" type="array" extend="true">
+				<element value="WP_CLI\Tests"/><!-- Namespaces. -->
+			</property>
 		</properties>
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 	</rule>
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	#############################################################################
+	-->
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<!-- Naming requirement from Behat, can't be changed to comply. -->
+		<exclude-pattern>*/features/bootstrap/FeatureContext\.php$</exclude-pattern>
+	</rule>
+
+	<!-- This is a procedural stand-alone file that is never loaded in a WordPress context,
+		 so this file does not have to comply with WP naming conventions. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>*/utils/behat-tags\.php$</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>*/utils/behat-tags\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 define( 'WP_CLI', true );
 define( 'WP_CLI_TESTS_ROOT', dirname( __DIR__ ) );
+
+// These constants are actively used by dependent projects, renaming them would be a BC-break.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define(
 	'VENDOR_DIR',
 	file_exists( WP_CLI_TESTS_ROOT . '/vendor/autoload.php' )
@@ -8,6 +11,7 @@ define(
 		: WP_CLI_TESTS_ROOT . '/../..'
 );
 define( 'PACKAGE_ROOT', VENDOR_DIR . '/..' );
+// phpcs:enable
 
 define(
 	'WP_CLI_ROOT',


### PR DESCRIPTION
A PHPCS standard is in principle the same as a custom ruleset with these differences:

Custom ruleset | External PHPCS standard
--- | ---
File: `[.]phpcs.xml[.dist]` | File: `ruleset.xml`
Can be included in other rulesets using the path to the file (which can get complicated) | Can be included in other rulesets by name
Can only use existing sniffs | Can add new sniffs native to the standard (not currently used)

Aside from that, one has to keep in mind that all paths used in a ruleset are interpreted _relative to the ruleset_.
As an external standard can be installed both globally as well as local to a project, it is better not to have any specifics involving file paths in an external standard, but to use a custom ruleset, which generally lives in the project root, for this instead.

So, this PR introduces a `WPCliCS` standard to the `wp-cli-tests` project which is a dependency for all WP-CLI projects, making this standard easily available to them all.

As the `dealerdirect/phpcodesniffer-composer-installer` plugin is a `require`ment for this project (and therefore all WP-CLI projects), this new `WPCliCS` standard will automatically be recognized and installed via the plugin.
No extra actions needed :sunglasses:

To see it in action, just run a `composer install`/`composer update` and then run `vendor/bin/phpcs -i` and `WPCliCS` should now be listed as one of the installed standards.

About the ruleset itself, there are a couple of things to take note of:
* Based on the information received in #34 - WP won't always be (fully) loaded when code from the WP-CLI commands is run, IMO it will be better to include the `PHPCompatibility` standard (stricter) than the `PHPCompatibilityWP` standard, as the polyfills which the `PHPCompatibilityWP` standard accounts for will not necessarily always be available.
    Includes adjusting the `composer.json` requirement to match.
* As not all project have the same minimum PHP version, the `testVersion` config setting is not set in the standard, but should be set in the custom ruleset of each project.
    While it _is_ possible since PHP 3.3.0 to overrule a `config` setting from the command-line, overruling it from a custom ruleset is still not possible, so it is better to set it in the custom ruleset in the first place.
* While the PHPCompatibility sniffs should be limited to `.php` files, the other sniffs shouldn't necessarily be limited to this, so instead of setting `<arg name="extensions" value="php"/>`, I'm using an `<include-pattern>` for the `PHPCompatibility` sniffs only.
    - Side-note: By default, PHPCS will scan files with the following file extensions: `.php`, `.inc` (interpreted as PHP), `.js` and `.css`. As most WP-CLI projects don't include `.js` or `.css` files (or `.inc` files for that matter), there is rarely a need to set limit the `extensions` from within a project ruleset.
    - Similarly, any directories which don't contain any of the above mentioned file types, don't need to be excluded via a `<exclude-pattern>` either, as PHPCS won't find any files to scan anyway.
    - Also, take note of the syntax used in the `<include-pattern>`. Both `<include-pattern>`s as well as `<exclude-pattern>`s are basically PHP PCRE regular expressions, with one caveat: any `*` in the pattern will automatically be replaced by `.*`.
        This also means that characters which have special meaning in a PCRE regex, like the `.` have to be escaped properly!
* In the base ruleset in the `wp-cli-tests` root (and in `wp-cli`), the `WordPress-Core` ruleset was included.
    While this is all well and good, the `WordPress-Extra` ruleset contains many additional sniffs for code quality as well as some sniffs for modern PHP code style, which is not yet covered in the Core code style handbook.
    As the WP-CLI projects use PHP 5.4 as a minimum, using the `WordPress-Extra` ruleset is IMO the better choice. Even though there are some exceptions to the rules which need to be made, the majority of the additional sniffs contained within the `Extra` ruleset will be valuable to scan against.
* A standard should be widely applicable and should not contain `<exclude>` exceptions which are solely for one project.
    This means that the `exclude`s which were used so far have largely been removed.
    Regarding the remaining (and new) `exclude`s:
    - The exclusion of the `array_column` detection is valid as the polyfill is shipped with `wp-cli` and therefore available to all WP-CLI projects.
    - The `Generic.PHP.Syntax` sniff basically does a `php -l` on a file. As linting the files is already done in a separate Travis job for all projects, this sniff is not needed.
    - The `WordPress.File.FileName` sniff conflicts with PSR-4, which is used for the autoloading of the WP-CLI files, so this is a legitimate exclusion.
    - The `WordPress.PHP.DiscouragedPHPFunctions` and `WordPress.WP.AlternativeFunctions` contain some recommendations which are not all that applicable for project running as cli, so the most typically problematic ones have been excluded.
         The same applies to the `Generic.PHP.BacktickOperator` sniff.
         Further exclusions can be made, if and when, needed from individual project-based rulesets.
    - Along the same lines, the `WordPress.PHP.DevelopmentFunctions` discourages the use of typical PHP dev related functions. As WP-CLI is a developers tool, I believe it is legitimate to use these functions in this context.
    - Lastly, variable output send to the command-line should probably use some form of escaping, but the output escaping functions the `WordPress.Security.EscapeOutput` sniff checks for are _HTML_output escaping functions, which are not applicable in this context.
        In the future, this standard could be extended with a custom sniff for output escaping for the command line.
        Similarly, a custom sniff to verify that arbitrary arguments passed to shell commands are escaped properly using `escapeshellcmd()` or `escapeshellarg()` should also be considered.
* I've added configuration for one particular sniff: `WordPress.NamingConventions.PrefixAllGlobals`.
    Even though the WP environment will not always be (fully) loaded, it oftentimes will be. In that case, naming conflicts between plugins and WP-CLI projects for names in the global namespace can occur.
    To that end, all WP-CLI code should be either namespaced or prefixed.
    As the sniff will just be silent if there is no configuration present, I've added the most generic configuration possible to still demand prefixes.
    Individual projects can overrule and/or - as of PHPCS 3.4.0 - add to this configuration from their own project ruleset.
* While I've added the PHPCS schema tags to the ruleset, the schema will not be able to validate correctly, unless PHPCS 3.3.2+ is used.
     PHPCS 3.3.0 introduced a new syntax for array elements to the rulesets, but the schema wasn't updated for this new syntax until PHPCS 3.3.2.

Fixes #34

## Other Changes

### bin/run-phpcs-tests: list config files in PHPCS precedence order

PHPCS 3.1.0 introduced the ability to use dot prefixed configuration files.
In PHPCS 3.1.1 the loading order of these got normalized.

So, in effect PHP will search for configuration files in this order:
1. `.phpcs.xml`
2. `phpcs.xml`
3. `.phpcs.xml.dist`
4. `phpcs.xml.dist`

This is just a minor tweak so the same order of preference is used in this script to list the possible config files.

Refs;
* https://github.com/squizlabs/PHP_CodeSniffer/releases/3.1.0
* https://github.com/squizlabs/PHP_CodeSniffer/releases/3.1.1

### Composer: temporarily require PHPCS

Strictly speaking PHPCS is not a requirement of *this* project, but a requirement of its dependencies WPCS + PHPCompatibility.

However, WPCS currently supports PHPCS `^2.9 || ^3.1` and PHPCompatibility still supports PHPCS all the way back to 2.3.

For the WP-CLI projects, it is preferred that these use a more recent PHPCS version.

Aside from the fact that this means that a lot of sniffs will be more accurate, this will also allow for using, for instance:
* The `basepath` setting for cleaner result reports.  (PHPCS 3.0+)
* The `parallel` setting for multi-threaded scanning.  (PHPCS 3.0+)
* The new, powerful PHPCS selective inline annotations. (PHPCS 3.2+)
* PHPCS on PHP 7.3. (PHPCS 3.3.1+)

Once WPCS 2.0 comes out, which is expected to have a PHPCS `^3.3.1` minimum requirement, the requirement in the composer file in this package can be removed.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/releases

### .gitignore/.distignore: ignore phpcs/phpunit config files

* `.distignore`: no need to distribute the phpcs/phpunit config files.
* `.gitignore`: Allow devs to overwrite config files for PHPUnit and PHPCS
    - The `.dist` files should be committed. However, for their personal use,  devs can overrule those files with versions without `.dist`.
        Those personal versions should never be committed.

As a side-note: for PHPCS, having a personal version while still using the  original `.dist` file is made very easy, as you can just import the `.dist` file  as a starting point, like so:
```xml
<?xml version="1.0"?>
<ruleset name="WP-CLI">
    <rule ref="./phpcs.xml.dist"/>
</ruleset>
```

### README/USING: add instructions on how projects can use the base ruleset 