### PR TITLE
Wrap Behat & PHPUnit bootstrapping code into a function

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -9,7 +9,7 @@ use WP_CLI\Utils;
 /**
  * Load required support files as needed before heading into the Behat context.
  */
-function wpcli_bootstrap_behat() {
+function wpcli_bootstrap_behat_feature_context() {
 	// Inside a community package
 	if ( file_exists( __DIR__ . '/utils.php' ) ) {
 		require_once __DIR__ . '/utils.php';
@@ -46,7 +46,7 @@ function wpcli_bootstrap_behat() {
 	}
 }
 
-wpcli_bootstrap_behat();
+wpcli_bootstrap_behat_feature_context();
 
 /**
  * Features context.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,26 +33,32 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
 require_once VENDOR_DIR . '/autoload.php';
 require_once WP_CLI_ROOT . '/php/utils.php';
 
-$config_filenames = array(
-	'phpunit.xml',
-	'.phpunit.xml',
-	'phpunit.xml.dist',
-	'.phpunit.xml.dist',
+function wpcli_tests_include_config( array $config_filenames = [] ) {
+	$config_filename = false;
+	foreach ( $config_filenames as $filename ) {
+		if ( file_exists( PACKAGE_ROOT . '/' . $filename ) ) {
+			$config_filename = PACKAGE_ROOT . '/' . $filename;
+			break;
+		}
+	}
+
+	if ( $config_filename ) {
+		$config  = file_get_contents( $config_filename );
+		$matches = null;
+		$pattern = '/bootstrap="(?P<bootstrap>.*)"/';
+		$result  = preg_match( $pattern, $config, $matches );
+		if ( isset( $matches['bootstrap'] ) && file_exists( $matches['bootstrap'] ) ) {
+			include_once PACKAGE_ROOT . '/' . $matches['bootstrap'];
+		}
+	}
+}
+
+wpcli_tests_include_config(
+	[
+		'phpunit.xml',
+		'.phpunit.xml',
+		'phpunit.xml.dist',
+		'.phpunit.xml.dist',
+	]
 );
 
-$config_filename = false;
-foreach ( $config_filenames as $filename ) {
-	if ( file_exists( PACKAGE_ROOT . '/' . $filename ) ) {
-		$config_filename = PACKAGE_ROOT . '/' . $filename;
-	}
-}
-
-if ( $config_filename ) {
-	$config  = file_get_contents( $config_filename );
-	$matches = null;
-	$pattern = '/bootstrap="(?P<bootstrap>.*)"/';
-	$result  = preg_match( $pattern, $config, $matches );
-	if ( isset( $matches['bootstrap'] ) && file_exists( $matches['bootstrap'] ) ) {
-		include_once PACKAGE_ROOT . '/' . $matches['bootstrap'];
-	}
-}


### PR DESCRIPTION
This removes the unprefixed variables from the global namespace to fix WPCS issues.

Related #44