### PR TITLE
Travis: Add QA-checks for the WP_CLI_CS ruleset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 before_install:
+  - export XMLLINT_INDENT="	"
   - |
     # Remove Xdebug for a huge performance increase:
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
@@ -46,9 +47,15 @@ script:
 jobs:
   include:
     - stage: sniff
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
       script:
         - composer lint
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
         - composer phpcs
+        - diff -B --tabsize=4 ./WP_CLI_CS/ruleset.xml <(xmllint --format "./WP_CLI_CS/ruleset.xml")
       env: BUILD=sniff
     - stage: test
       php: 7.2

--- a/WP_CLI_CS/ruleset.xml
+++ b/WP_CLI_CS/ruleset.xml
@@ -86,8 +86,10 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="WP_CLI"/><!-- Namespaces and non-namespaced classes. -->
-				<element value="wpcli"/><!-- Global variables and functions. -->
+				<!-- Namespaces and non-namespaced classes. -->
+				<element value="WP_CLI"/>
+				<!-- Global variables and functions. -->
+				<element value="wpcli"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
This adds two checks:
1. Validation of the `WP_CLI_CS` ruleset against the PHPCS ruleset format as defined in the XSD file.
2. A check that the ruleset is formatted consistently, i.e. using tab indents, indented correctly, valid strict XML etc.

Both these checks need the `libxml2-utils` package to be available and both checks only need to be run once as the output will not change based on PHP versions.

As the `libxml2-utils` package is not a package which can be required via Composer, it did not make sense to add these commands as Composer scripts as, in that case, the `xmllint` package may not be available on the machine running the commands.

With that in mind and as these checks will only be needed for this repo and not for the project repos, I've added the necessary changes straight into the `.travis.yml` file.

Alternatively, the two command lines could be extracted to a bash script in the `bin` directory and that script then called directly from the Travis script (bypassing Composer), but that would still leave the environment variable definition and the `addons` directive in the Travis script, so doesn't really do all that much.

Includes minor tweak to the ruleset to make it pass the second check :wink:.