### PR TITLE
Always show sniff name in addition to error message

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,9 @@
 	<!-- Show progress. -->
 	<arg value="p"/>
 
+	<!-- Show rule name. -->
+	<arg value="s"/>
+
 	<!-- Strip the filepaths down to the relevant bit. -->
 	<arg name="basepath" value="./"/>
 


### PR DESCRIPTION
Showing the sniff name makes it easier to whitelist issues if needed.