### PR TITLE
Fix ID comparison

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -431,7 +431,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				$parent = $matches[1];
 				$child  = $matches[2];
 
-				if ( $parent === $master_pid ) {
+				if ( (int) $parent === (int) $master_pid ) {
 					self::terminate_proc( $child );
 				}
 			}


### PR DESCRIPTION
The ID comparison failed to detect parent/child relationships due to the strict check.

Related #46