### PR TITLE
Fix MySQL8 column-statistics compatibility issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,3 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
-    - stage: test
-      php: 7.2
-      mysql: 8.0
-      env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,7 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
+    - stage: test
+      php: 7.2
+      mysql: 8.0
+      env: WP_VERSION=latest

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -857,7 +857,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				mkdir( $install_cache_path );
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
-				$mysqldump_binary = Utils\force_env_on_nix_systems( 'mysqldump' );
+				$mysqldump_binary          = Utils\force_env_on_nix_systems( 'mysqldump' );
 				$support_column_statistics = exec( "{$mysqldump_binary} --help | grep 'column-statistics'" );
 				$command                   = 'mysqldump --no-defaults';
 				if ( $support_column_statistics ) {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -857,7 +857,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				mkdir( $install_cache_path );
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
-				$support_column_statistics = exec( 'mysqldump --help | grep "column-statistics"' );
+				$support_column_statistics = exec( '/usr/bin/env mysqldump --help | grep "column-statistics"' );
 				$command                   = '/usr/bin/env mysqldump --no-defaults';
 				if ( $support_column_statistics ) {
 					$command .= ' --skip-column-statistics';

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -858,7 +858,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
 				$support_column_statistics = exec( '/usr/bin/env mysqldump --help | grep "column-statistics"' );
-				$command                   = '/usr/bin/env mysqldump --no-defaults';
+				$command                   = 'mysqldump --no-defaults';
 				if ( $support_column_statistics ) {
 					$command .= ' --skip-column-statistics';
 				}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -857,7 +857,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 				mkdir( $install_cache_path );
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
-				$support_column_statistics = exec( '/usr/bin/env mysqldump --help | grep "column-statistics"' );
+				$mysqldump_binary = Utils\force_env_on_nix_systems( 'mysqldump' );
+				$support_column_statistics = exec( "{$mysqldump_binary} --help | grep 'column-statistics'" );
 				$command                   = 'mysqldump --no-defaults';
 				if ( $support_column_statistics ) {
 					$command .= ' --skip-column-statistics';


### PR DESCRIPTION
This pull request ensures that column-statistics is not used if supported by the user's version of mysql.  If column-statistics are supported by the user's version of mysql supports column-statistics, the  `--skip-column-statistics` tag is added to the `mysqldump` command. 

This is related to #4, wp-cli/db-command#103, and wp-cli/db-command#105