### PR TITLE
Update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "^2.5",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6",
         "jakub-onderka/php-console-highlighter": "^0.4",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phpcompatibility/php-compatibility": "^9",


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.6.0`.
As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Note: As underlying standards may not have updated their requirements for this plugin yet, I've kept the requirement flexible so as to prevent conflicts.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-
