### PR TITLE
Update install-package-tests

### DIFF
--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -4,9 +4,10 @@ set -ex
 
 # Prepare the database for running the tests
 install_db() {
-	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
-	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
-	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot -p${DB_PASSWORD}
+	mysql -e 'CREATE USER "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot -p${DB_PASSWORD}
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost"' -uroot -p${DB_PASSWORD}
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost"' -uroot -p${DB_PASSWORD}
 }
 
 install_db


### PR DESCRIPTION
**Proposed changes**

* Pass root password via env variable. 
* Fallback to requesting password for each command.
* Fix granting privileges for MySQL 8.0. [See here](https://stackoverflow.com/questions/50177216/how-to-grant-all-privileges-to-root-user-in-mysql-8-0).

**Testing instructions**

* Install MySQL 8.0
* Clone [wp-cli-dev](https://github.com/wp-cli/wp-cli-dev)
* Install its composer dependencies.
* Enter one of the project folders, e.g. `wp-cli`
* Run `DB_PASSWORD=root_password_here composer prepare-tests`. It should run without errors.


