### PR TITLE
Reuse Behat `WP_CLI_TEST_*` constants for `prepare-tests` script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
-dist: trusty
+os: linux
+dist: xenial
 
 language: php
-php: 7.2
+php: 7.4
+
+services:
+  - mysql
 
 notifications:
   email:
@@ -51,12 +54,20 @@ jobs:
         apt:
           packages:
             - libxml2-utils
+      install:
+        - composer install
       script:
         - composer lint
         - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml
         - composer phpcs
         - diff -B --tabsize=4 ./WP_CLI_CS/ruleset.xml <(xmllint --format "./WP_CLI_CS/ruleset.xml")
       env: BUILD=sniff
+    - stage: test
+      php: 7.4
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
     - stage: test
       php: 7.2
       env: WP_VERSION=latest
@@ -75,7 +86,3 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk
-    - stage: test
-      php: 5.4
-      dist: precise
-      env: WP_VERSION=5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 before_install:
+  - export XMLLINT_INDENT=" "
   - |
     # Remove Xdebug for a huge performance increase:
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -8,34 +8,59 @@
 HOST=localhost
 PORT=""
 HOST_STRING=''
-if [ ! -z "$WP_CLI_TEST_DBHOST" ]; then
+if [ -n "$WP_CLI_TEST_DBHOST" ]; then
 	case ${WP_CLI_TEST_DBHOST##*[]]} in
 		(*:*) HOST=${WP_CLI_TEST_DBHOST%:*} PORT=${WP_CLI_TEST_DBHOST##*:};;
 		(*)   HOST=$WP_CLI_TEST_DBHOST;;
 	esac
   HOST_STRING="-h$HOST"
-  if [ ! -z "$PORT" ]; then
+  if [ -n "$PORT" ]; then
   	HOST_STRING="$HOST_STRING -P$PORT"
 	fi
 fi
 
 USER=root
-if [ ! -z "$WP_CLI_TEST_DBUSER" ]; then
+if [ -n "$WP_CLI_TEST_DBUSER" ]; then
   USER="$WP_CLI_TEST_DBUSER"
 fi
 
 PASSWORD_STRING=""
-if [ ! -z "$WP_CLI_TEST_DBPASS" ]; then
+if [ -n "$WP_CLI_TEST_DBPASS" ]; then
   PASSWORD_STRING="-p$WP_CLI_TEST_DBPASS"
 fi
 
-set -ex
-
-# Prepare the database for running the tests.
-install_db() {
+# Prepare the database for running the tests with a MySQL version 5.7 or higher.
+install_db_5_7_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'"" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'"" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
-install_db
+# Prepare the database for running the tests with a MySQL version 5.7 or higher.
+install_db_5_6_or_lower() {
+	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+}
+
+set -ex
+
+VERSION_STRING=$(mysql -e "SELECT VERSION()" --skip-column-names $HOST_STRING -u"$USER" "$PASSWORD_STRING")
+VERSION=$(echo "$VERSION_STRING" | grep -o '[^-]*$')
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+if [ "$MAJOR" -eq 5 ]; then
+	if [ "$MINOR" -gt 6 ]; then
+		install_db_5_7_plus
+	else
+		install_db_5_6_or_lower
+	fi
+else
+	if [ "$MAJOR" -gt 5 ]; then
+		install_db_5_7_plus
+	else
+		install_db_5_6_or_lower
+	fi
+fi

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -34,9 +34,8 @@ set -ex
 # Prepare the database for running the tests.
 install_db() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'"" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'"" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 install_db

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -32,16 +32,16 @@ fi
 # Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO wp_cli_test@$HOST" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO wp_cli_test@$HOST" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 # Prepare the database for running the tests with a MySQL version lower than 8.0.
 install_db_lower_than_8_0() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test.* TO wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 set -ex

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -34,7 +34,7 @@ set -ex
 # Prepare the database for running the tests.
 install_db() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -30,7 +30,7 @@ if [ -n "$WP_CLI_TEST_DBPASS" ]; then
 fi
 
 # Prepare the database for running the tests with a MySQL version 5.7 or higher.
-install_db_5_7_plus() {
+install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
@@ -38,7 +38,7 @@ install_db_5_7_plus() {
 }
 
 # Prepare the database for running the tests with a MySQL version 5.7 or higher.
-install_db_5_6_or_lower() {
+install_db_lower_than_8_0() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
@@ -53,14 +53,14 @@ MINOR=$(echo "$VERSION" | cut -d. -f2)
 
 if [ "$MAJOR" -eq 5 ]; then
 	if [ "$MINOR" -gt 6 ]; then
-		install_db_5_7_plus
+		install_db_8_0_plus
 	else
-		install_db_5_6_or_lower
+		install_db_lower_than_8_0
 	fi
 else
 	if [ "$MAJOR" -gt 5 ]; then
-		install_db_5_7_plus
+		install_db_8_0_plus
 	else
-		install_db_5_6_or_lower
+		install_db_lower_than_8_0
 	fi
 fi

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -15,7 +15,7 @@ if [ -n "$WP_CLI_TEST_DBHOST" ]; then
 	esac
   HOST_STRING="-h$HOST"
   if [ -n "$PORT" ]; then
-  	HOST_STRING="$HOST_STRING -P$PORT"
+  	HOST_STRING="$HOST_STRING -P$PORT --protocol=tcp"
 	fi
 fi
 

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -29,7 +29,7 @@ if [ -n "$WP_CLI_TEST_DBPASS" ]; then
   PASSWORD_STRING="-p$WP_CLI_TEST_DBPASS"
 fi
 
-# Prepare the database for running the tests with a MySQL version 5.7 or higher.
+# Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "CREATE USER IF NOT EXISTS 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
@@ -37,7 +37,7 @@ install_db_8_0_plus() {
 	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
-# Prepare the database for running the tests with a MySQL version 5.7 or higher.
+# Prepare the database for running the tests with a MySQL version lower than 8.0.
 install_db_lower_than_8_0() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL ON wp_cli_test.* TO 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
@@ -51,16 +51,8 @@ VERSION=$(echo "$VERSION_STRING" | grep -o '^[^-]*')
 MAJOR=$(echo "$VERSION" | cut -d. -f1)
 MINOR=$(echo "$VERSION" | cut -d. -f2)
 
-if [ "$MAJOR" -eq 5 ]; then
-	if [ "$MINOR" -gt 6 ]; then
-		install_db_8_0_plus
-	else
-		install_db_lower_than_8_0
-	fi
+if [ "$MAJOR" -ge 8 ]; then
+	install_db_8_0_plus
 else
-	if [ "$MAJOR" -gt 5 ]; then
-		install_db_8_0_plus
-	else
-		install_db_lower_than_8_0
-	fi
+	install_db_lower_than_8_0
 fi

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -1,18 +1,42 @@
 #!/bin/sh
 
-set -ex
+# Database credentials can be provided via environment variables:
+# - WP_CLI_TEST_DBHOST is the host to use and can include a port, i.e "127.0.0.1:33060" (defaults to "localhost:3306")
+# - WP_CLI_TEST_DBUSER is the user that has permission to administer databases and users (defaults to "root").
+# - WP_CLI_TEST_DBPASS is the password to use for the above user (defaults to an empty password).
+
+HOST=localhost
+PORT=""
+HOST_STRING=''
+if [ ! -z "$WP_CLI_TEST_DBHOST" ]; then
+	case ${WP_CLI_TEST_DBHOST##*[]]} in
+		(*:*) HOST=${WP_CLI_TEST_DBHOST%:*} PORT=${WP_CLI_TEST_DBHOST##*:};;
+		(*)   HOST=$WP_CLI_TEST_DBHOST;;
+	esac
+  HOST_STRING="-h$HOST"
+  if [ ! -z "$PORT" ]; then
+  	HOST_STRING="$HOST_STRING -P$PORT"
+	fi
+fi
+
+USER=root
+if [ ! -z "$WP_CLI_TEST_DBUSER" ]; then
+  USER="$WP_CLI_TEST_DBUSER"
+fi
 
 PASSWORD_STRING=""
-if [ -z "DB_PASSWORD" ]; then
-  PASSWORD_STRING="-p${DB_PASSWORD}"
-fi;
+if [ ! -z "$WP_CLI_TEST_DBPASS" ]; then
+  PASSWORD_STRING="-p$WP_CLI_TEST_DBPASS"
+fi
 
-# Prepare the database for running the tests
+set -ex
+
+# Prepare the database for running the tests.
 install_db() {
-	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot "$PASSWORD_STRING"
-	mysql -e 'CREATE USER "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot "$PASSWORD_STRING"
-	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost"' -uroot "$PASSWORD_STRING"
-	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost"' -uroot "$PASSWORD_STRING"
+	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER 'wp_cli_test@$HOST' IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO 'wp_cli_test@$HOST'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 install_db

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Database credentials can be provided via environment variables:
-# - WP_CLI_TEST_DBHOST is the host to use and can include a port, i.e "127.0.0.1:33060" (defaults to "localhost:3306")
+# - WP_CLI_TEST_DBHOST is the host to use and can include a port, i.e "127.0.0.1:33060" (defaults to "localhost")
 # - WP_CLI_TEST_DBUSER is the user that has permission to administer databases and users (defaults to "root").
 # - WP_CLI_TEST_DBPASS is the password to use for the above user (defaults to an empty password).
 

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -47,7 +47,7 @@ install_db_5_6_or_lower() {
 set -ex
 
 VERSION_STRING=$(mysql -e "SELECT VERSION()" --skip-column-names $HOST_STRING -u"$USER" "$PASSWORD_STRING")
-VERSION=$(echo "$VERSION_STRING" | grep -o '[^-]*$')
+VERSION=$(echo "$VERSION_STRING" | grep -o '^[^-]*')
 MAJOR=$(echo "$VERSION" | cut -d. -f1)
 MINOR=$(echo "$VERSION" | cut -d. -f2)
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "behat/behat": "^2.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "php-parallel-lint/php-parallel-lint": "^1.0",
+        "php-parallel-lint/php-parallel-lint": "^1",
         "phpcompatibility/php-compatibility": "^9",
         "phpunit/phpunit": ">=4.8 <7",
         "wp-cli/config-command": "^1 || ^2",
@@ -23,8 +23,7 @@
         "wp-coding-standards/wpcs": "^2.1"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
-        "wp-cli/regenerate-readme": "^2"
+        "roave/security-advisories": "dev-master"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
Database credentials for `composer prepare-tests` can now be provided via the same environment variables that `composer behat` accepts:

- `WP_CLI_TEST_DBHOST` is the host to use and can include a port, i.e `127.0.0.1:33060` (defaults to `localhost`)
- `WP_CLI_TEST_DBUSER` is the user that has permission to administer databases and users (defaults to `root`).
- `WP_CLI_TEST_DBPASS` is the password to use for the above user (defaults to an empty password).