### PR TITLE
Allow negated match for both file contents and `STDOUT|STDERR` checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
-dist: trusty
+os: linux
+dist: xenial
 
 language: php
-php: 7.2
+php: 7.4
+
+services:
+  - mysql
 
 notifications:
   email:
@@ -58,6 +61,12 @@ jobs:
         - diff -B --tabsize=4 ./WP_CLI_CS/ruleset.xml <(xmllint --format "./WP_CLI_CS/ruleset.xml")
       env: BUILD=sniff
     - stage: test
+      php: 7.4
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.2
       env: WP_VERSION=latest
     - stage: test
@@ -72,10 +81,7 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=3.7.11
+      dist: trusty
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk
-    - stage: test
-      php: 5.4
-      dist: precise
-      env: WP_VERSION=5.1

--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -15,6 +15,12 @@ function assert_regex( $regex, $actual ) {
 	}
 }
 
+function assert_not_regex( $regex, $actual ) {
+	if ( preg_match( $regex, $actual ) ) {
+		throw new Exception( 'Actual value: ' . var_export( $actual, true ) );
+	}
+}
+
 function assert_equals( $expected, $actual ) {
 	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Deliberate loose comparison.
 	if ( $expected != $actual ) {

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -225,23 +225,31 @@ $steps->Then(
 );
 
 $steps->Then(
-	'/^the contents of the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
-	function ( $world, $path, $expected ) {
+	'/^the contents of the (.+) file should( not)? match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $path, $not, $expected ) {
 		$path = $world->replace_variables( $path );
 		// If it's a relative path, make it relative to the current test dir.
 		if ( '/' !== $path[0] ) {
 			$path = $world->variables['RUN_DIR'] . "/$path";
 		}
 		$contents = file_get_contents( $path );
-		Support\assert_regex( $expected, $contents );
+		if ( $not ) {
+			Support\assert_not_regex( $expected, $contents );
+		} else {
+			Support\assert_regex( $expected, $contents );
+		}
 	}
 );
 
 $steps->Then(
-	'/^(STDOUT|STDERR) should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
-	function ( $world, $stream, $expected ) {
+	'/^(STDOUT|STDERR) should( not)? match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $stream, $not, $expected ) {
 		$stream = strtolower( $stream );
-		Support\assert_regex( $expected, $world->result->$stream );
+		if ( $not ) {
+			Support\assert_not_regex( $expected, $world->result->$stream );
+		} else {
+			Support\assert_regex( $expected, $world->result->$stream );
+		}
 	}
 );
 


### PR DESCRIPTION
This PR adds the possibility to negate the following rules by adding a `not`:
* `/^the contents of the (.+) file should( not)? match (((\/.+\/)|(#.+#))([a-z]+)?)$/`
* `/^(STDOUT|STDERR) should( not)? match (((\/.+\/)|(#.+#))([a-z]+)?)$/`
