### PR TITLE
Update dependency requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "type" : "phpcodesniffer-standard",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "behat/behat": "^2.5.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7",
         "php-parallel-lint/php-console-highlighter": "^0.5",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type" : "phpcodesniffer-standard",
     "require": {
         "php": ">=5.4",
-        "behat/behat": "^2.5",
+        "behat/behat": "^2.5.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "php-parallel-lint/php-parallel-lint": "^1",
@@ -27,7 +27,7 @@
     },
     "config": {
         "platform": {
-            "php": "5.4"
+            "php": "5.6"
         },
         "sort-packages": true
     },


### PR DESCRIPTION
This PR:
- ensures a Behat minimum of v2.5.5
- raises the minimum PHP version to v5.6
- sets the PHP platform requirement to v5.6