### PR TITLE
Use --no-tablespaces by default for mysqldump

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -875,7 +875,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 				$mysqldump_binary          = Utils\force_env_on_nix_systems( 'mysqldump' );
 				$support_column_statistics = exec( "{$mysqldump_binary} --help | grep 'column-statistics'" );
-				$command                   = 'mysqldump --no-defaults';
+				$command                   = "{$mysqldump_binary} --no-defaults --no-tablespaces";
 				if ( $support_column_statistics ) {
 					$command .= ' --skip-column-statistics';
 				}


### PR DESCRIPTION
This is needed to avoid permission errors starting with MySQL 5.7.31.

See https://github.com/wp-cli/db-command/issues/180