### PR TITLE
Use `composer prepare-tests` in GHA workflows

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,7 +6,11 @@ jobs:
 
   lint: #-----------------------------------------------------------------------
     name: Lint PHP files
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
@@ -55,7 +59,7 @@ jobs:
 
   phpcs: #----------------------------------------------------------------------
     name: PHPCS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out source code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -141,9 +141,7 @@ jobs:
           echo "WP_CLI_TEST_DBUSER=wp_cli_test" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBPASS=password1" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBHOST=$MYSQL_HOST:$MYSQL_TCP_PORT" >> $GITHUB_ENV
-          mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" -uroot -proot
-          mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test\`.* TO 'wp_cli_test'@'%' IDENTIFIED BY 'password1';" -uroot -proot
-          mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test_scaffold\`.* TO 'wp_cli_test'@'%' IDENTIFIED BY 'password1';" -uroot -proot
+          composer prepare-tests
 
       - name: Run Behat
         if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,11 +103,12 @@ jobs:
 
     services:
       mysql:
-        image: mysql:${{ matrix.mysql }}
+        image: bitnami/mysql:${{ matrix.mysql }}
         env:
           MYSQL_DATABASE: wp_cli_test
           MYSQL_USER: root
           MYSQL_ROOT_PASSWORD: root
+          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         ports:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -149,10 +150,6 @@ jobs:
       - name: Install dependencies
         if: steps.check_files.outputs.files_exists == 'true'
         run: COMPOSER_ROOT_VERSION=dev-master composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Configure MySQL server
-        if: steps.check_files.outputs.files_exists == 'true'
-        run: echo -e '[mysqld]\ndefault-authentication-plugin=mysql_native_password' > "$HOME/.my.cnf"
 
       - name: Start MySQL server
         if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -110,7 +110,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --default-authentication-plugin="mysql_native_password" --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Check out source code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -154,7 +154,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'true'
         run: sudo systemctl start mysql
 
-      - name: Prepare test database
+      - name: Configure DB environment
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
           export MYSQL_HOST=127.0.0.1
@@ -162,7 +162,10 @@ jobs:
           echo "WP_CLI_TEST_DBUSER=wp_cli_test" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBPASS=password1" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBHOST=$MYSQL_HOST:$MYSQL_TCP_PORT" >> $GITHUB_ENV
-          composer prepare-tests
+
+      - name: Prepare test database
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: composer prepare-tests
 
       - name: Run Behat
         if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,25 +64,46 @@ jobs:
       matrix:
         php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
         wp: ['latest']
+        mysql: ['8.0']
         test: ["composer behat || composer behat-rerun"]
         include:
           - php: '5.6'
             wp: 'trunk'
+            mysql: '8.0'
+            test: "composer behat || composer behat-rerun"
+          - php: '5.6'
+            wp: 'trunk'
+            mysql: '5.7'
+            test: "composer behat || composer behat-rerun"
+          - php: '5.6'
+            wp: 'trunk'
+            mysql: '5.6'
             test: "composer behat || composer behat-rerun"
           - php: '7.4'
             wp: 'trunk'
+            mysql: '8.0'
             test: "composer behat || composer behat-rerun"
           - php: '8.0'
             wp: 'trunk'
+            mysql: '8.0'
+            test: "composer behat || composer behat-rerun"
+          - php: '8.0'
+            wp: 'trunk'
+            mysql: '5.7'
+            test: "composer behat || composer behat-rerun"
+          - php: '8.0'
+            wp: 'trunk'
+            mysql: '5.6'
             test: "composer behat || composer behat-rerun"
           - php: '5.6'
             wp: '3.7'
+            mysql: '5.6'
             test: "composer behat || composer behat-rerun"
     runs-on: ubuntu-latest
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:${{ matrix.mysql }}
         env:
           MYSQL_DATABASE: wp_cli_test
           MYSQL_USER: root

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -110,8 +110,12 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          - 3306/tcp
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
       - name: Check out source code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -110,7 +110,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306
-        options: --default-authentication-plugin="mysql_native_password" --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Check out source code
@@ -149,6 +149,10 @@ jobs:
       - name: Install dependencies
         if: steps.check_files.outputs.files_exists == 'true'
         run: COMPOSER_ROOT_VERSION=dev-master composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Configure MySQL server
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: echo -e '[mysqld]\ndefault-authentication-plugin=mysql_native_password' > "$HOME/.my.cnf"
 
       - name: Start MySQL server
         if: steps.check_files.outputs.files_exists == 'true'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out source code
@@ -99,7 +99,7 @@ jobs:
             wp: '3.7'
             mysql: '5.6'
             test: "composer behat || composer behat-rerun"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       mysql:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -159,6 +159,8 @@ jobs:
         run: |
           export MYSQL_HOST=127.0.0.1
           export MYSQL_TCP_PORT=${{ job.services.mysql.ports['3306'] }}
+          echo "WP_CLI_TEST_DBROOTUSER=root" >> $GITHUB_ENV
+          echo "WP_CLI_TEST_DBROOTPASS=root" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBUSER=wp_cli_test" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBPASS=password1" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBHOST=$MYSQL_HOST:$MYSQL_TCP_PORT" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
         run: composer phpunit
 
   functional: #----------------------------------------------------------------------
-    name: Functional - WP ${{ matrix.wp }} on PHP ${{ matrix.php }}
+    name: Functional - WP ${{ matrix.wp }} on PHP ${{ matrix.php }} with MySQL ${{ matrix.mysql }}
     strategy:
       fail-fast: false
       matrix:

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -2,8 +2,10 @@
 
 # Database credentials can be provided via environment variables:
 # - WP_CLI_TEST_DBHOST is the host to use and can include a port, i.e "127.0.0.1:33060" (defaults to "localhost")
-# - WP_CLI_TEST_DBUSER is the user that has permission to administer databases and users (defaults to "root").
-# - WP_CLI_TEST_DBPASS is the password to use for the above user (defaults to an empty password).
+# - WP_CLI_TEST_DBROOTUSER is the user that has permission to administer databases and users (defaults to "root").
+# - WP_CLI_TEST_DBROOTPASS is the password to use for the above user (defaults to an empty password).
+# - WP_CLI_TEST_DBUSER is the user that the tests run under (defaults to "wp_cli_test").
+# - WP_CLI_TEST_DBPASS is the password to use for the above user (defaults to "password1").
 
 HOST=localhost
 PORT=""
@@ -20,28 +22,28 @@ if [ -n "$WP_CLI_TEST_DBHOST" ]; then
 fi
 
 USER=root
-if [ -n "$WP_CLI_TEST_DBUSER" ]; then
-  USER="$WP_CLI_TEST_DBUSER"
+if [ -n "$WP_CLI_TEST_DBROOTUSER" ]; then
+  USER="$WP_CLI_TEST_DBROOTUSER"
 fi
 
 PASSWORD_STRING=""
-if [ -n "$WP_CLI_TEST_DBPASS" ]; then
-  PASSWORD_STRING="-p$WP_CLI_TEST_DBPASS"
+if [ -n "$WP_CLI_TEST_DBROOTPASS" ]; then
+  PASSWORD_STRING="-p$WP_CLI_TEST_DBROOTPASS"
 fi
 
 # Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
-	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER IF NOT EXISTS wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO wp_cli_test@%" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO wp_cli_test@%" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS \`wp_cli_test\`@$HOST IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test_scaffold\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 # Prepare the database for running the tests with a MySQL version lower than 8.0.
 install_db_lower_than_8_0() {
-	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test.* TO wp_cli_test@% IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO wp_cli_test@% IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON \`wp_cli_test\`.* TO '$TEST_USER'@'%' IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON \`wp_cli_test_scaffold\`.* TO '$TEST_USER'@'%' IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 set -ex

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -33,15 +33,15 @@ fi
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "CREATE USER IF NOT EXISTS wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO wp_cli_test@$HOST" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO wp_cli_test@$HOST" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test.* TO wp_cli_test@%" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO wp_cli_test@%" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 # Prepare the database for running the tests with a MySQL version lower than 8.0.
 install_db_lower_than_8_0() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS wp_cli_test;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test.* TO wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO wp_cli_test@$HOST IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test.* TO wp_cli_test@% IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "GRANT ALL ON wp_cli_test_scaffold.* TO wp_cli_test@% IDENTIFIED BY 'password1'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }
 
 set -ex

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -44,7 +44,7 @@ fi
 # Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER IF NOT EXISTS \`wp_cli_test\`@'%' IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS \`wp_cli_test\`@'%' IDENTIFIED WITH mysql_native_password BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test_scaffold\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -44,7 +44,7 @@ fi
 # Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
-	mysql -e "CREATE USER IF NOT EXISTS \`wp_cli_test\`@$HOST IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
+	mysql -e "CREATE USER IF NOT EXISTS \`wp_cli_test\`@'%' IDENTIFIED BY '$TEST_PASSWORD'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 	mysql -e "GRANT ALL PRIVILEGES ON \`wp_cli_test_scaffold\`.* TO '$TEST_USER'@'%'" $HOST_STRING -u"$USER" "$PASSWORD_STRING"
 }

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -31,6 +31,16 @@ if [ -n "$WP_CLI_TEST_DBROOTPASS" ]; then
   PASSWORD_STRING="-p$WP_CLI_TEST_DBROOTPASS"
 fi
 
+TEST_USER=wp_cli_test
+if [ -n "$WP_CLI_TEST_DBUSER" ]; then
+  TEST_USER="$WP_CLI_TEST_DBUSER"
+fi
+
+TEST_PASSWORD=password1
+if [ -n "$WP_CLI_TEST_DBPASS" ]; then
+  TEST_PASSWORD="$WP_CLI_TEST_DBPASS"
+fi
+
 # Prepare the database for running the tests with a MySQL version 8.0 or higher.
 install_db_8_0_plus() {
 	mysql -e "CREATE DATABASE IF NOT EXISTS \`wp_cli_test\`;" $HOST_STRING -u"$USER" "$PASSWORD_STRING"


### PR DESCRIPTION
Instead of hardcoding the SQL statements to prepare the DB into the GHA workflow, reuse `composer prepare-tests` instead.
