### PR TITLE
Add DB root user & pass to Behat vars

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -504,12 +504,12 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		$this->drop_db();
 		$this->set_cache_dir();
-		$this->variables['DB_ROOT_USER']         = self::$db_settings['dbrootuser'];
-		$this->variables['DB_ROOT_PASSWORD']     = self::$db_settings['dbrootpass'];
 		$this->variables['DB_USER']              = self::$db_settings['dbuser'];
 		$this->variables['DB_PASSWORD']          = self::$db_settings['dbpass'];
 		$this->variables['DB_HOST']              = self::$db_settings['dbhost'];
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
+		$this->variables['DB_ROOT_USER']         = self::$db_settings['dbrootuser'];
+		$this->variables['DB_ROOT_PASSWORD']     = self::$db_settings['dbrootpass'];
 	}
 
 	/**

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -502,14 +502,14 @@ class FeatureContext implements SnippetAcceptingContext {
 			$this->variables['DB_HOST'] = getenv( 'WP_CLI_TEST_DBHOST' );
 		}
 
-		$this->drop_db();
-		$this->set_cache_dir();
-
 		self::$db_settings['dbuser'] = $this->variables['DB_USER'];
 		self::$db_settings['dbpass'] = $this->variables['DB_PASSWORD'];
 		self::$db_settings['dbhost'] = $this->variables['DB_HOST'];
 
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
+
+		$this->drop_db();
+		$this->set_cache_dir();
 	}
 
 	/**

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -483,33 +483,33 @@ class FeatureContext implements SnippetAcceptingContext {
 	 */
 	public function __construct() {
 		if ( getenv( 'WP_CLI_TEST_DBROOTUSER' ) ) {
-			self::$db_settings['dbrootuser'] = getenv( 'WP_CLI_TEST_DBROOTUSER' );
+			$this->variables['DB_ROOT_USER'] = getenv( 'WP_CLI_TEST_DBROOTUSER' );
 		}
 
 		if ( false !== getenv( 'WP_CLI_TEST_DBROOTPASS' ) ) {
-			self::$db_settings['dbrootpass'] = getenv( 'WP_CLI_TEST_DBROOTPASS' );
+			$this->variables['DB_ROOT_PASSWORD'] = getenv( 'WP_CLI_TEST_DBROOTPASS' );
 		}
 
 		if ( getenv( 'WP_CLI_TEST_DBUSER' ) ) {
-			self::$db_settings['dbuser'] = getenv( 'WP_CLI_TEST_DBUSER' );
+			$this->variables['DB_USER'] = getenv( 'WP_CLI_TEST_DBUSER' );
 		}
 
 		if ( false !== getenv( 'WP_CLI_TEST_DBPASS' ) ) {
-			self::$db_settings['dbpass'] = getenv( 'WP_CLI_TEST_DBPASS' );
+			$this->variables['DB_PASSWORD'] = getenv( 'WP_CLI_TEST_DBPASS' );
 		}
 
 		if ( getenv( 'WP_CLI_TEST_DBHOST' ) ) {
-			self::$db_settings['dbhost'] = getenv( 'WP_CLI_TEST_DBHOST' );
+			$this->variables['DB_HOST'] = getenv( 'WP_CLI_TEST_DBHOST' );
 		}
 
 		$this->drop_db();
 		$this->set_cache_dir();
-		$this->variables['DB_USER']              = self::$db_settings['dbuser'];
-		$this->variables['DB_PASSWORD']          = self::$db_settings['dbpass'];
-		$this->variables['DB_HOST']              = self::$db_settings['dbhost'];
+
+		self::$db_settings['dbuser'] = $this->variables['DB_USER'];
+		self::$db_settings['dbpass'] = $this->variables['DB_PASSWORD'];
+		self::$db_settings['dbhost'] = $this->variables['DB_HOST'];
+
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
-		$this->variables['DB_ROOT_USER']         = self::$db_settings['dbrootuser'];
-		$this->variables['DB_ROOT_PASSWORD']     = self::$db_settings['dbrootpass'];
 	}
 
 	/**

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -482,6 +482,14 @@ class FeatureContext implements SnippetAcceptingContext {
 	 * Every scenario gets its own context object.
 	 */
 	public function __construct() {
+		if ( getenv( 'WP_CLI_TEST_DBROOTUSER' ) ) {
+			self::$db_settings['dbrootuser'] = getenv( 'WP_CLI_TEST_DBROOTUSER' );
+		}
+
+		if ( false !== getenv( 'WP_CLI_TEST_DBROOTPASS' ) ) {
+			self::$db_settings['dbrootpass'] = getenv( 'WP_CLI_TEST_DBROOTPASS' );
+		}
+
 		if ( getenv( 'WP_CLI_TEST_DBUSER' ) ) {
 			self::$db_settings['dbuser'] = getenv( 'WP_CLI_TEST_DBUSER' );
 		}
@@ -496,6 +504,8 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		$this->drop_db();
 		$this->set_cache_dir();
+		$this->variables['DB_ROOT_USER']         = self::$db_settings['dbrootuser'];
+		$this->variables['DB_ROOT_PASSWORD']     = self::$db_settings['dbrootpass'];
 		$this->variables['DB_USER']              = self::$db_settings['dbuser'];
 		$this->variables['DB_PASSWORD']          = self::$db_settings['dbpass'];
 		$this->variables['DB_HOST']              = self::$db_settings['dbhost'];


### PR DESCRIPTION
This adds `DB_ROOT_USER` & `DB_ROOT_PASSWORD` to the array of variables that can be used within Behat tests for substituion.