### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        },
         "readme": {
             "sections": [
                 "Using",


### PR DESCRIPTION
Add a branch alias `3.0.x-dev` to the package so that `dev-master` can count as a `^3` release when the stability flag matches.