### PR TITLE
Update behat.yml in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ To make use of the WP-CLI testing framework, you need to complete the following 
     The timeout is expressed in seconds.
 
 4. Optionally add a `behat.yml` file to the package root with the following content:
-    ```json
+    ```yaml
     default:
-      paths:
-        features: features
-        bootstrap: vendor/wp-cli/wp-cli-tests/features/bootstrap
+      suites:
+        default:
+          contexts:
+            - WP_CLI\Tests\Context\FeatureContext
+          paths:
+            - features
     ```
     This will make sure that the automated Behat system works across all platforms. This is needed on Windows.
 


### PR DESCRIPTION
Pretty self-explanatory change – the current example isn't valid (at least with v3 of Behat). Essentially copied from [the current `behat.yml`](https://github.com/wp-cli/wp-cli-tests/blob/03fdabdae9e9a081ef57b0ce7e6d66dc45212c09/behat.yml).