### PR TITLE
Update test `wp_mail`

### DIFF
--- a/utils/no-mail.php
+++ b/utils/no-mail.php
@@ -1,18 +1,26 @@
 <?php
 /**
- * This file is copied as amu-plugin into new WP installs to reroute normal
+ * This file is copied as a mu-plugin into new WP installs to reroute normal
  * mails into log entries.
  */
 
 /**
  * Replace WP native pluggable wp_mail function for test purposes.
  *
- * @param string $to Email address.
+ * @param string|string[] $to Array or comma-separated list of email addresses to send message.
+ * @return bool Whether the email was sent successfully.
  *
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WP native function.
  */
 function wp_mail( $to ) {
+	if ( is_array( $to ) ) {
+		$to = join( ', ', $to );
+	}
+
 	// Log for testing purposes
 	WP_CLI::log( "WP-CLI test suite: Sent email to {$to}." );
+
+	// Assume sending mail always succeeds.
+	return true;
 }
 // phpcs:enable


### PR DESCRIPTION
This PR updates the bundled test implementation of `wp_mail` to work slightly closer to the real implementation.

Most importantly, it returns `true` to indicate mail was successfully sent (this is how the function worked before as well). It also supports a potential array of recipients, as supported by the core function to avoid a potential array-to-string conversion error in the event an array is passed.