### PR TITLE
Update file/folder existence check for cache safety

### DIFF
--- a/src/Context/ThenStepDefinitions.php
+++ b/src/Context/ThenStepDefinitions.php
@@ -196,25 +196,32 @@ trait ThenStepDefinitions {
 			$path = $this->variables['RUN_DIR'] . "/$path";
 		}
 
-		if ( 'file' === $type ) {
-			$test = 'file_exists';
-		} elseif ( 'directory' === $type ) {
-			$test = 'is_dir';
-		}
+		$exists = function ( $path ) use ( $type ) {
+			// Clear the stat cache for the path first to avoid
+			// potentially inaccurate results when files change outside of PHP.
+			// See https://www.php.net/manual/en/function.clearstatcache.php
+			clearstatcache( false, $path );
+
+			if ( 'directory' === $type ) {
+				return is_dir( $path );
+			}
+
+			return file_exists( $path );
+		};
 
 		switch ( $action ) {
 			case 'exist':
-				if ( ! $test( $path ) ) {
+				if ( ! $exists( $path ) ) {
 					throw new Exception( "$path doesn't exist." );
 				}
 				break;
 			case 'not exist':
-				if ( $test( $path ) ) {
+				if ( $exists( $path ) ) {
 					throw new Exception( "$path exists." );
 				}
 				break;
 			default:
-				if ( ! $test( $path ) ) {
+				if ( ! $exists( $path ) ) {
 					throw new Exception( "$path doesn't exist." );
 				}
 				$action   = substr( $action, 0, -1 );


### PR DESCRIPTION
Updates Behat then step definition for checking whether a given file or folder exists or not to fix an edge case where it could report inaccurate results due to PHP's internal cache for filesystem metadata.

It also changes the name of the test function to be more expressive as the "test" is specific to existence, so it makes sense to name it accordingly 🙂 

Here's a POC script showing the problem in general. From my testing, `is_dir` is perhaps the only problem here, although [docs mention `file_exists` (among many others)](https://www.php.net/manual/en/function.clearstatcache.php), although I wasn't able to reproduce the same with `file_exists` (as shown below) so perhaps it's a bit better than it used to be on newer versions of PHP 🤷‍♂️ 

```php
$to_str = fn( $data ) => var_export( $data, true );
$log = fn( ...$args ) => print join( ' ', array_map( $to_str, $args ) ) . "\n";
// Set up a temp directory to create and delete some files in...
$temp_dir = sys_get_temp_dir() . '/' . uniqid( 'php-test-' );
mkdir( $temp_dir );
chdir( $temp_dir );

// Test file_exists()
$log( 'test file exists?', file_exists( 'test' ) );
$log( 'create test via system command', system( "touch test" ) );
$log( 'test file exists?', file_exists( 'test' ) );
$log( 'remove test via system command', system( "rm test" ) );
$log( 'test file exists?', file_exists( 'test' ) );

$log( "Looking good so far." );

// Test is_dir()
$log( 'testdir directory exists?', is_dir( 'testdir' ) );
$log( 'create testdir via system command', system( "mkdir testdir" ) );
$log( 'testdir directory exists?', is_dir( 'testdir' ) );
$log( 'remove testdir via system command', system( "rm -rf testdir" ) );
// is_dir will now return a cached result.
$log( 'testdir directory exists?', is_dir( 'testdir' ) );

$log( 'no, testdir directory does not exist:', file_exists( 'testdir' ) );

// Also, using `file_exists` did not invalidate the cached value :sad:
$log( 'testdir directory exists?', is_dir( 'testdir' ) );
```

<details>
<summary>output</summary>

```
'test file exists?' false
'create test via system command' ''
'test file exists?' true
'remove test via system command' ''
'test file exists?' false
'Looking good so far.'
'testdir directory exists?' false
'create testdir via system command' ''
'testdir directory exists?' true
'remove testdir via system command' ''
'testdir directory exists?' true
'no, testdir directory does not exist:' false
'testdir directory exists?' true
```

</details>