### PR TITLE
Strip ANSI colors on string comparison

### DIFF
--- a/src/Context/Support.php
+++ b/src/Context/Support.php
@@ -51,6 +51,9 @@ trait Support {
 	}
 
 	protected function check_string( $output, $expected, $action, $message = false ) {
+		// Strip ANSI color codes before comparing strings.
+		$output = preg_replace( '/\e[[][A-Za-z0-9];?[0-9]*m?/', '', $output );
+
 		switch ( $action ) {
 			case 'be':
 				$r = rtrim( $output, "\n" ) === $expected;


### PR DESCRIPTION
When comparing two strings, this PR strips the contained ANSI color codes, as these should not be a factor in whether the strings match.