### PR TITLE
Add strict mode to string comparisons

### DIFF
--- a/src/Context/Support.php
+++ b/src/Context/Support.php
@@ -50,9 +50,11 @@ trait Support {
 		}
 	}
 
-	protected function check_string( $output, $expected, $action, $message = false ) {
+	protected function check_string( $output, $expected, $action, $message = false, $strictly = false ) {
 		// Strip ANSI color codes before comparing strings.
-		$output = preg_replace( '/\e[[][A-Za-z0-9];?[0-9]*m?/', '', $output );
+		if ( ! $strictly ) {
+			$output = preg_replace( '/\e[[][A-Za-z0-9];?[0-9]*m?/', '', $output );
+		}
 
 		switch ( $action ) {
 			case 'be':

--- a/src/Context/ThenStepDefinitions.php
+++ b/src/Context/ThenStepDefinitions.php
@@ -25,15 +25,15 @@ trait ThenStepDefinitions {
 	}
 
 	/**
-	 * @Then /^(STDOUT|STDERR) should (be|contain|not contain):$/
+	 * @Then /^(STDOUT|STDERR) should( strictly)? (be|contain|not contain):$/
 	 */
-	public function then_stdout_stderr_should_contain( $stream, $action, PyStringNode $expected ) {
+	public function then_stdout_stderr_should_contain( $stream, $strictly, $action, PyStringNode $expected ) {
 
 		$stream = strtolower( $stream );
 
 		$expected = $this->replace_variables( (string) $expected );
 
-		$this->check_string( $this->result->$stream, $expected, $action, $this->result );
+		$this->check_string( $this->result->$stream, $expected, $action, $this->result, (bool) $strictly );
 	}
 
 	/**


### PR DESCRIPTION
As a follow-up to #130, this PR adds an optional strict mode to string comparison in case the actual ANSI codes need to be checked.