### PR TITLE
Include `WP_CLI_ALLOW_ROOT` in process env variables

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -222,6 +222,11 @@ class FeatureContext implements SnippetAcceptingContext {
 			$env['WP_CLI_CONFIG_PATH'] = $config_path;
 		}
 
+		$allow_root = getenv( 'WP_CLI_ALLOW_ROOT' );
+		if ( false !== $allow_root ) {
+			$env['WP_CLI_ALLOW_ROOT'] = $allow_root;
+		}
+
 		$term = getenv( 'TERM' );
 		if ( false !== $term ) {
 			$env['TERM'] = $term;


### PR DESCRIPTION
The test setup apparently does not include the `WP_CLI_ALLOW_ROOT` variable into the `wp cli` process that would cause some commands to fail when initialising the test.

```bash
root@3d05a502038c:/var/www/workspace/packages/composer/wp-cli# composer behat
> run-behat-tests
---

--- Failed hooks:

    BeforeSuite # WP_CLI\Tests\Context\FeatureContext::prepare()
      │ 
      │ OS:     Linux 5.10.47-linuxkit #1 SMP Sat Jul 3 21:51:47 UTC 2021 x86_64
      │ Shell:
      │ PHP binary:     /usr/local/bin/php
      │ PHP version:    7.4.25
      │ php.ini used:   /usr/local/etc/php/php.ini
      │ MySQL binary:   /usr/bin/mysql
      │ MySQL version:  mysql  Ver 15.1 Distrib 10.5.12-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper
      │ SQL modes:
      │ WP-CLI root dir:        /var/www/workspace/packages/composer/wp-cli/vendor/wp-cli/wp-cli
      │ WP-CLI vendor dir:      /var/www/workspace/packages/composer/wp-cli/vendor
      │ WP_CLI phar path:
      │ WP-CLI packages dir:
      │ WP-CLI global config:   /tmp/wp-cli-package-test/config.yml
      │ WP-CLI project config:
      │ WP-CLI version: 2.5.0
      │ 
      │ 
      $ wp core version --debug --path='/tmp/wp-cli-test-core-download-cache-5.8.1'
      ***REDACTED***
     Error: YIKES! It looks like you're running this as root. You probably meant to run this as the user that your WordPress installation exists under.
```

This PR includes the `WP_CLI_ALLOW_ROOT` variable to the process env variables. Running as root may be a common use case when performing the test inside Docker containers.

After adding the variable, the test runs without any issues.

```bash
root@3d05a502038c:/var/www/workspace/packages/composer/wp-cli# composer behat
> run-behat-tests
...

1 scenario (1 passed)
3 steps (3 passed)
0m5.71s (3.80Mb)
root@3d05a502038c:/var/www/workspace/packages/composer/wp-cli#
```