### PR TITLE
Use latest branch for Roave security advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "yoast/phpunit-polyfills": "^1.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-latest"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
See details here -> https://github.com/Roave/SecurityAdvisories#stability