### PR TITLE
Improve Behat binaries

### DIFF
--- a/bin/rerun-behat-tests
+++ b/bin/rerun-behat-tests
@@ -1,37 +1,20 @@
 #!/bin/bash
 
-# Run the Behat tests only if a features folder exists
-if [ ! -d "features" ]; then
-  exit 0;
-fi
-
-# Turn WP_VERSION into an actual number to make sure our tags work correctly.
-if [ "${WP_VERSION-latest}" = "latest" ]; then
-	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
-fi
-
-# To retrieve the Behat root folder, we start with this scripts location
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
 SOURCE="${BASH_SOURCE[0]}"
 
-# Resolve $SOURCE until the file is no longer a symlink
+# Resolve $SOURCE until the file is no longer a symlink.
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
   # If $SOURCE was a relative symlink, we need to resolve it relative to the
-  # path where the symlink file was located
+  # path where the symlink file was located.
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 
-# Fetch the root folder of the Behat package
-BEHAT_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
-export BEHAT_ROOT
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+export WP_CLI_TESTS_ROOT
 
-# Set Behat environment variables
-BEHAT_PARAMS="{\"suites\":{\"default\":{\"contexts\":[\"WP_CLI\\\\Tests\\\\Context\\\\FeatureContext\"],\"paths\":[\"features\"]}}}"
-export BEHAT_PARAMS
-
-# Generate the tags to apply environment-specific filters
-BEHAT_TAGS=$(php "$BEHAT_ROOT"/utils/behat-tags.php)
-
-# Run the functional tests
-vendor/bin/behat --format progress "$BEHAT_TAGS" --strict --rerun "$@"
+"$WP_CLI_TESTS_ROOT"/bin/run-behat-tests --rerun "$@"

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Run the Behat tests only if a features folder exists
-if [ ! -d "features" ]; then
-	echo 'Did not detect "features" directory, skipping Behat tests.'
+# Run the Behat tests only if a Behat config file is found.
+if [ ! -f "behat.yml" ]; then
+	echo 'Did not detect "behat.yml" file, skipping Behat tests.'
   exit 0;
 fi
 
@@ -13,35 +13,30 @@ then
     exit 1;
 fi
 
-rm -f ".behat-progress.log"
-
 # Turn WP_VERSION into an actual number to make sure our tags work correctly.
 if [ "${WP_VERSION-latest}" = "latest" ]; then
 	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
 fi
 
-# To retrieve the Behat root folder, we start with this scripts location
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
 SOURCE="${BASH_SOURCE[0]}"
 
-# Resolve $SOURCE until the file is no longer a symlink
+# Resolve $SOURCE until the file is no longer a symlink.
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
   # If $SOURCE was a relative symlink, we need to resolve it relative to the
-  # path where the symlink file was located
+  # path where the symlink file was located.
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 
-# Fetch the root folder of the Behat package
-BEHAT_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
-export BEHAT_ROOT
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+export WP_CLI_TESTS_ROOT
 
-# Set Behat environment variables
-BEHAT_PARAMS="{\"suites\":{\"default\":{\"contexts\":[\"WP_CLI\\\\Tests\\\\Context\\\\FeatureContext\"],\"paths\":[\"features\"]}}}"
-export BEHAT_PARAMS
+# Generate the tags to apply environment-specific filters.
+BEHAT_TAGS=$(php "$WP_CLI_TESTS_ROOT"/utils/behat-tags.php)
 
-# Generate the tags to apply environment-specific filters
-BEHAT_TAGS=$(php "$BEHAT_ROOT"/utils/behat-tags.php)
-
-# Run the functional tests
-vendor/bin/behat --format progress "$BEHAT_TAGS" --strict --rerun "$@"
+# Run the functional tests.
+vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "$@"


### PR DESCRIPTION
This PR:

1. Changes the check for bailing early on Behat execution from the `features/` directory to the `behat.yml` file. Fixes #126 .
2. Changes `--rerun` usage to take changes from Behat v2 to Behat v3 into consideration.
3. Makes `rerun-behat-tests` reuse `run-behat-tests`, to avoid duplicating all of the logix.