### PR TITLE
Allow all plugins before requiring plugins 😉

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -939,10 +939,10 @@ class FeatureContext implements SnippetAcceptingContext {
 		$this->composer_command( 'init --name="wp-cli/composer-test" --type="project"' );
 		$this->composer_command( 'config vendor-dir ' . $vendor_directory );
 		$this->composer_command( 'config extra.wordpress-install-dir WordPress' );
-		$this->composer_command( 'require johnpbloch/wordpress-core-installer johnpbloch/wordpress-core --optimize-autoloader' );
 
 		// Allow for all Composer plugins to run to avoid warnings.
-		$this->composer_command( 'config allow-plugins true' );
+		$this->composer_command( 'config --no-plugins allow-plugins true' );
+		$this->composer_command( 'require johnpbloch/wordpress-core-installer johnpbloch/wordpress-core --optimize-autoloader' );
 
 		// Disable WP Cron by default to avoid bogus HTTP requests in CLI context.
 		$config_extra_php = "if ( ! defined( 'DISABLE_WP_CRON' ) ) { define( 'DISABLE_WP_CRON', true ); }\n";


### PR DESCRIPTION
This may overcome the wp-cli/wp-cli CI errors.

https://github.com/Lewiscowles1986/wp-cli-tests/pull/5 shows it as green (although these don't seem to be gated in the same way wp-cli is)