### PR TITLE
Add explicit default branch for local `wp-cli` package

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -978,7 +978,7 @@ class FeatureContext implements SnippetAcceptingContext {
 			self::remove_dir( self::$composer_local_repository . '/vendor' );
 		}
 		$dest = self::$composer_local_repository . '/';
-		$this->composer_command( "config repositories.wp-cli '{\"type\": \"path\", \"url\": \"$dest\", \"options\": {\"symlink\": false}}'" );
+		$this->composer_command( "config repositories.wp-cli '{\"type\": \"path\", \"url\": \"$dest\", \"options\": {\"symlink\": false, \"versions\": { \"wp-cli/wp-cli\": \"dev-master\"}}}'" );
 		$this->variables['COMPOSER_LOCAL_REPOSITORY'] = self::$composer_local_repository;
 	}
 


### PR DESCRIPTION
When adding a `path` repository without explicit version information, Composer has switched to using `main` as the default development branch, instead of `master`. As `wp-cli/wp-cli` is still using `master` as the default branch, we need to be explicit about this.