### PR TITLE
Composer: allow for the 1.0.0 version of the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.6",
         "behat/behat": "^3.7",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "^9.3.5",


### PR DESCRIPTION
The Composer PHPCS plugin has released its 1.0.0 version. :tada:

Important:
I've _widened_ the version constraints for the plugin, instead of _bumping_ it.

The reason for this is to prevent conflicts with end-user projects/other external PHPCS standards which may also require(-dev) the plugin, but may not (yet) have updated _their_ constraints for the plugin. If the version would have been bumped instead of widened, those users would get an unsolvable conflict during the `composer install` run (unless they `require-dev` the plugin for the root project, but then, that's exactly what we _don't_ want them to do as external standards managing the versions of the plugins should  be more reliable).

The version constraints now set cover all released versions which support external standards properly.

Ref: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
