### PR TITLE
Add ability to mark tests as broken on `trunk` and `nightly`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 	colors="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="default">
 			<directory prefix="spec-" suffix=".php">tests/</directory>
 			<directory prefix="test-" suffix=".php">tests/</directory>
 		</testsuite>

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -44,7 +44,12 @@ class BehatTagsTest extends TestCase {
 		file_put_contents( $this->temp_dir . '/features/wp_version.feature', $contents );
 
 		$output = exec( "cd {$this->temp_dir}; $env php $behat_tags" );
-		$this->assertSame( '--tags=' . $expected . '&&~@broken', $output );
+
+		$expected .= '&&~@broken';
+		if ( in_array( $env, array( 'WP_VERSION=trunk', 'WP_VERSION=nightly' ), true ) ) {
+			$expected .= '&&~@broken-trunk';
+		}
+		$this->assertSame( '--tags=' . $expected, $output );
 
 		putenv( false === $env_wp_version ? 'WP_VERSION' : "WP_VERSION=$env_wp_version" );
 		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -76,6 +76,10 @@ if ( ! getenv( 'GITHUB_TOKEN' ) ) {
 # Skip tests known to be broken.
 $skip_tags[] = '@broken';
 
+if ( $wp_version && in_array( $wp_version, array( 'nightly', 'trunk' ), true ) ) {
+	$skip_tags[] = '@broken-trunk';
+}
+
 # Require PHP extension, eg 'imagick'.
 function extension_tags( $features_folder = 'features' ) {
 	$extension_tags = array();


### PR DESCRIPTION
There's one more failing test on https://github.com/wp-cli/extension-command/pull/347 that's specific to trunk: https://core.trac.wordpress.org/ticket/54504#comment:117

Rather than mark the entire test as failed, I want to only mark it failed for `WP_VERSION=trunk` and `WP_VERSION=nightly`.