### PR TITLE
Fix PHP 8.2 deprication warnings

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -21,6 +21,9 @@ class FeatureContext implements SnippetAcceptingContext {
 	use ThenStepDefinitions;
 	use WhenStepDefinitions;
 
+	private $result;
+	private $email_sends;
+
 	/**
 	 * The current working directory for scenarios that have a "Given a WP installation" or "Given an empty directory" step. Variable RUN_DIR. Lives until the end of the scenario.
 	 */

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -21,7 +21,14 @@ class FeatureContext implements SnippetAcceptingContext {
 	use ThenStepDefinitions;
 	use WhenStepDefinitions;
 
+	/**
+	 * The result of the last command run with `When I run` or `When I try`. Lives until the end of the scenario.
+	 */
 	private $result;
+
+	/**
+	 * The number of emails sent by the last command run with `When I run` or `When I try`. Lives until the end of the scenario.
+	 */
 	private $email_sends;
 
 	/**


### PR DESCRIPTION
This fixes the following warnings I saw:

` 8192: Creation of dynamic property WP_CLI\Tests\Context\FeatureContext::$result is deprecated in /wp-cli-tests/src/Context/WhenStepDefinitions.php line 39`

`8192: Creation of dynamic property WP_CLI\Tests\Context\FeatureContext::$email_sends is deprecated in /wp-cli-dev/wp-cli-tests/src/Context/WhenStepDefinitions.php line 40
`

Which cause some behat tests to fail under PHP 8.2

All of the other variables in this class a very well commented, so this needs some input from anybody who has a good description of these two.