### PR TITLE
Avoid error when using `composer behat -- --help`

### DIFF
--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -13,6 +13,12 @@ then
     exit 1;
 fi
 
+if [[ "$@" == *"--help"* ]]; then
+    vendor/bin/behat "$@"
+    ret=$?
+    exit $ret
+fi
+
 # Turn WP_VERSION into an actual number to make sure our tags work correctly.
 if [ "${WP_VERSION-latest}" = "latest" ]; then
 	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")


### PR DESCRIPTION
Before:

```
$ composer behat -- --help
> run-behat-tests '--help'

  Unsupported format "progress".

help [--format FORMAT] [--raw] [--] [<command_name>]

Script run-behat-tests handling the behat event returned with error code 1
```

Related https://github.com/wp-cli/handbook/pull/440