### PR TITLE
Update `FeatureContext::$result` and `FeatureContext::$email_sends` visibility

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -24,12 +24,12 @@ class FeatureContext implements SnippetAcceptingContext {
 	/**
 	 * The result of the last command run with `When I run` or `When I try`. Lives until the end of the scenario.
 	 */
-	private $result;
+	protected $result;
 
 	/**
 	 * The number of emails sent by the last command run with `When I run` or `When I try`. Lives until the end of the scenario.
 	 */
-	private $email_sends;
+	protected $email_sends;
 
 	/**
 	 * The current working directory for scenarios that have a "Given a WP installation" or "Given an empty directory" step. Variable RUN_DIR. Lives until the end of the scenario.


### PR DESCRIPTION
The `FeatureContext::$result` and `FeatureContext::$email_sends` properties were defined with private visibility as part of #165, which is now preventing the child class from using them in the event that more step definitions are added.

This PR seeks to restore the previous functionality, in which the child class was permitted access to the properties listed above.

