### PR TITLE
Add missing filesystem function exclsuions

### DIFF
--- a/WP_CLI_CS/ruleset.xml
+++ b/WP_CLI_CS/ruleset.xml
@@ -79,9 +79,23 @@
 		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 
 		<!-- Allow filesystem operations because WordPress APIs may not be available -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chgrp" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chmod" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_chown" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fclose" />
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fopen" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fputs" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fread" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fsockopen" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_fwrite" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_is_writable" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_is_writeable" />
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_mkdir" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_pfsockopen" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_readfile" />
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_rmdir" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_touch" />
 		<exclude name="WordPress.WP.AlternativeFunctions.rename_rename" />
 		<exclude name="WordPress.WP.AlternativeFunctions.unlink_unlink" />
 

--- a/WP_CLI_CS/ruleset.xml
+++ b/WP_CLI_CS/ruleset.xml
@@ -145,7 +145,7 @@
 			<property name="exclude" type="array">
 				<element value="curl"/>
 				<element value="file_get_contents"/>
-				<element value="file_system_read"/>
+				<element value="file_system_operations"/>
 				<!-- As PHP 5.4. is the minimum for most projects, using json_encode() is fine. -->
 				<element value="json_encode"/>
 			</property>


### PR DESCRIPTION
This PR updates the custom PHPCS ruleset to exclude all current filesystem functions to the list of exclusions.