### PR TITLE
Look into `getcwd()` first when searching for vendor folder

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -111,6 +111,8 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		// We try to detect the vendor folder in the most probable locations.
 		$vendor_locations = [
+			// wp-cli/wp-cli-tests is a dependency of the current working dir.
+			getcwd() . '/vendor',
 			// wp-cli/wp-cli-tests is the root project.
 			dirname( dirname( __DIR__ ) ) . '/vendor',
 			// wp-cli/wp-cli-tests is a dependency.


### PR DESCRIPTION
When the Behat context setup tried to find the `vendor` folder, it did not look into the current working folder first, instead always finding the `vendor` folder within the tests dependency instead.

This PR adapts the logic so that the current working directory gets searched first.

As an example, when running `composer behat` from within the `wp-cli-dev/config-command` folder, this  is the resulting change:

**BEFORE**
```
Vendor folder location: /home/alain/dev/wp-cli-dev/wp-cli-tests/vendor
Framework folder location: /home/alain/dev/wp-cli-dev/wp-cli-tests/vendor/wp-cli/wp-cli
WP-CLI binary path: /home/alain/dev/wp-cli-dev/wp-cli-tests/vendor/bin
```

**AFTER**
```
Vendor folder location: /home/alain/dev/wp-cli-dev/config-command/vendor
Framework folder location: /home/alain/dev/wp-cli-dev/config-command/vendor/wp-cli/wp-cli
WP-CLI binary path: /home/alain/dev/wp-cli-dev/config-command/vendor/bin
```