### PR TITLE
Add support for running tests against SQLite database

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -68,6 +68,11 @@ class FeatureContext implements SnippetAcceptingContext {
 	];
 
 	/**
+	 *  What type of database should WordPress use for the test installations. Default to MySQL
+	 */
+	private static $db_type = 'MYSQL';
+
+	/**
 	 * Array of background process ids started by the current scenario. Used to terminate them at the end of the scenario.
 	 */
 	private $running_procs = [];
@@ -320,6 +325,56 @@ class FeatureContext implements SnippetAcceptingContext {
 	}
 
 	/**
+	 * Download and configure a copy of the SQLite plugin. This will add the db.php dropin to our cached
+	 * copy of WordPress files that are used for each scenario
+	 */
+	private static function download_and_configure_sqlite_plugin( $dir ) {
+		$download_url      = 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
+		$download_location = $dir . '/wp-content/plugins/sqlite-database-integration.zip';
+		Process::create(
+			Utils\esc_cmd(
+				'curl -sSfL %1$s > %2$s && chmod +x %2$s',
+				$download_url,
+				$download_location
+			)
+		)->run_check();
+
+		$zip            = new \ZipArchive();
+		$new_zip_file   = $download_location;
+		$plugins_folder = $dir . '/wp-content/plugins/';
+
+		if ( $zip->open( $new_zip_file ) === true ) {
+			if ( $zip->extractTo( $plugins_folder ) ) {
+				$zip->close();
+			} else {
+				$error_message = $zip->getStatusString();
+				throw new RuntimeException( sprintf( 'Failed to extract files from the zip: %s', $error_message ) );
+			}
+		} else {
+			$error_message = $zip->getStatusString();
+			throw new RuntimeException( sprintf( 'Failed to open the zip file: %s', $error_message ) );
+		}
+
+		$db_copy   = $plugins_folder . '/sqlite-database-integration/db.copy';
+		$db_dropin = self::$cache_dir . '/wp-content/db.php';
+
+		/* similar to https://github.com/WordPress/sqlite-database-integration/blob/3306576c9b606bc23bbb26c15383fef08e03ab11/activate.php#L95 */
+		$file_contents = str_replace(
+			array(
+				'\'{SQLITE_IMPLEMENTATION_FOLDER_PATH}\'',
+				'{SQLITE_PLUGIN}',
+			),
+			array(
+				'__DIR__ . \'plugins/sqlite-database-integration\'',
+				'sqlite-database-integration/load.php',
+			),
+			file_get_contents( $db_copy )
+		);
+
+		file_put_contents( $db_dropin, $file_contents );
+	}
+
+	/**
 	 * We cache the results of `wp core download` to improve test performance.
 	 * Ideally, we'd cache at the HTTP layer for more reliable tests.
 	 */
@@ -329,6 +384,11 @@ class FeatureContext implements SnippetAcceptingContext {
 		self::$cache_dir   = sys_get_temp_dir() . '/wp-cli-test-core-download-cache' . $wp_version_suffix;
 
 		if ( is_readable( self::$cache_dir . '/wp-config-sample.php' ) ) {
+			if ( 'SQLITE' === getenv( 'DB_TYPE' ) ) {
+				if ( ! is_readable( self::$cache_dir . '/wp-content/db.php' ) ) {
+					self::download_and_configure_sqlite_plugin( self::$cache_dir );
+				}
+			}
 			return;
 		}
 
@@ -337,6 +397,10 @@ class FeatureContext implements SnippetAcceptingContext {
 			$cmd .= Utils\esc_cmd( ' --version=%s', $wp_version );
 		}
 		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
+
+		if ( 'SQLITE' === getenv( 'DB_TYPE' ) ) {
+			self::download_and_configure_sqlite_plugin( self::$cache_dir );
+		}
 	}
 
 	/**
@@ -531,6 +595,10 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		if ( getenv( 'MYSQL_HOST' ) ) {
 			$this->variables['MYSQL_HOST'] = getenv( 'MYSQL_HOST' );
+		}
+
+		if ( 'SQLITE' === getenv( 'DB_TYPE' ) ) {
+			self::$db_type = 'SQLITE';
 		}
 
 		self::$db_settings['dbname'] = $this->variables['DB_NAME'];
@@ -741,6 +809,11 @@ class FeatureContext implements SnippetAcceptingContext {
 	 * @param bool $add_database Optional. Whether to add dbname to the $sql_cmd. Default false.
 	 */
 	private static function run_sql( $sql_cmd, $assoc_args = [], $add_database = false ) {
+		/* Can't run SQL against SQLite yet */
+		if ( 'SQLITE' === self::$db_type ) {
+			return;
+		}
+
 		$default_assoc_args = [
 			'host' => self::$db_settings['dbhost'],
 			'user' => self::$db_settings['dbuser'],
@@ -757,11 +830,18 @@ class FeatureContext implements SnippetAcceptingContext {
 	}
 
 	public function create_db() {
+		if ( 'SQLITE' === self::$db_type ) {
+			return;
+		}
+
 		$dbname = self::$db_settings['dbname'];
 		self::run_sql( 'mysql --no-defaults', [ 'execute' => "CREATE DATABASE IF NOT EXISTS $dbname" ] );
 	}
 
 	public function drop_db() {
+		if ( 'SQLITE' === self::$db_type ) {
+			return;
+		}
 		$dbname = self::$db_settings['dbname'];
 		self::run_sql( 'mysql --no-defaults', [ 'execute' => "DROP DATABASE IF EXISTS $dbname" ] );
 	}
@@ -894,7 +974,9 @@ class FeatureContext implements SnippetAcceptingContext {
 		// Disable WP Cron by default to avoid bogus HTTP requests in CLI context.
 		$config_extra_php = "if ( ! defined( 'DISABLE_WP_CRON' ) ) { define( 'DISABLE_WP_CRON', true ); }\n";
 
-		$this->create_db();
+		if ( 'MYSQL' === self::$db_type ) {
+			$this->create_db();
+		}
 		$this->create_run_dir();
 		$this->download_wp( $subdir );
 		$this->create_config( $subdir, $config_extra_php );
@@ -916,21 +998,33 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		if ( $install_cache_path && file_exists( $install_cache_path ) ) {
 			self::copy_dir( $install_cache_path, $run_dir );
-			self::run_sql( 'mysql --no-defaults', [ 'execute' => "source {$install_cache_path}.sql" ], true /*add_database*/ );
+
+			/* This is the sqlite equivilant of restoring a database dump in MySQL*/
+			if ( 'SQLITE' === self::$db_type ) {
+				copy( "{$install_cache_path}.sqlite", "$run_dir/wp-content/database/.ht.sqlite" );
+			} else {
+				self::run_sql( 'mysql --no-defaults', [ 'execute' => "source {$install_cache_path}.sql" ], true /*add_database*/ );
+			}
 		} else {
 			$this->proc( 'wp core install', $install_args, $subdir )->run_check();
 			if ( $install_cache_path ) {
 				mkdir( $install_cache_path );
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
-				$mysqldump_binary          = Utils\force_env_on_nix_systems( 'mysqldump' );
-				$support_column_statistics = exec( "{$mysqldump_binary} --help | grep 'column-statistics'" );
-				$command                   = "{$mysqldump_binary} --no-defaults --no-tablespaces";
-				if ( $support_column_statistics ) {
-					$command .= ' --skip-column-statistics';
+				if ( 'MYSQL' === self::$db_type ) {
+					$mysqldump_binary          = Utils\force_env_on_nix_systems( 'mysqldump' );
+					$support_column_statistics = exec( "{$mysqldump_binary} --help | grep 'column-statistics'" );
+					$command                   = "{$mysqldump_binary} --no-defaults --no-tablespaces";
+					if ( $support_column_statistics ) {
+						$command .= ' --skip-column-statistics';
+					}
+					self::run_sql( $command, [ 'result-file' => "{$install_cache_path}.sql" ], true /*add_database*/ );
 				}
 
-				self::run_sql( $command, [ 'result-file' => "{$install_cache_path}.sql" ], true /*add_database*/ );
+				if ( 'SQLITE' === self::$db_type ) {
+					/* This is the sqlite equivilant of creating a database dump in MySQL*/
+					copy( "$run_dir/wp-content/database/.ht.sqlite", "{$install_cache_path}.sqlite" );
+				}
 			}
 		}
 	}
@@ -965,6 +1059,10 @@ class FeatureContext implements SnippetAcceptingContext {
 			'admin_password' => 'password1',
 			'skip-email'     => true,
 		];
+
+		if ( 'SQLITE' === self::$db_type ) {
+			self::download_and_configure_sqlite_plugin( $this->variables['RUN_DIR'] . '/WordPress' );
+		}
 
 		$this->proc( 'wp core install', $install_args )->run_check();
 	}

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -73,6 +73,10 @@ if ( ! getenv( 'GITHUB_TOKEN' ) ) {
 	$skip_tags[] = '@github-api';
 }
 
+if ( 'SQLITE' === getenv( 'DB_TYPE' ) ) {
+	$skip_tags[] = '@require-mysql';
+}
+
 # Skip tests known to be broken.
 $skip_tags[] = '@broken';
 


### PR DESCRIPTION
Add initial support for running tests against a SQLite database using the SQLite Database Integration plugin from https://wordpress.org/plugins/sqlite-database-integration/

This is the first step of https://github.com/wp-cli/wp-cli/issues/5831

Right now you can see it works for the two basic tests in this project with:

`export DB_TYPE=SQLITE; composer behat`

Tests in other projects that require MySQL can be updated with the `@require-mysql` tag after it is added here.

This doesn't change anything about current CI testing since it requires a new environment flag, but it will give individual contributors the option to run against SQLite.