### PR TITLE
Rename DB_TYPE env variable into WP_CLI_TEST_DBTYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The following environment variables can be set to override the default database 
   - `WP_CLI_TEST_DBNAME` is the database that the tests run under (defaults to "wp_cli_test").
   - `WP_CLI_TEST_DBUSER` is the user that the tests run under (defaults to "wp_cli_test").
   - `WP_CLI_TEST_DBPASS` is the password to use for the above user (defaults to "password1").
+  - `WP_CLI_TEST_DBTYPE` is the database engine type to use, i.e. "sqlite" for running tests on SQLite instead of MySQL (defaults to "mysql").
 
 Environment variables can be set for the whole session via the following syntax: `export WP_CLI_TEST_DBNAME=custom_db`.
 

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -400,7 +400,7 @@ class FeatureContext implements SnippetAcceptingContext {
 		self::$cache_dir        = sys_get_temp_dir() . '/wp-cli-test-core-download-cache' . $wp_version_suffix;
 		self::$sqlite_cache_dir = sys_get_temp_dir() . '/wp-cli-test-sqlite-integration-cache';
 
-		if ( 'sqlite' === getenv( 'DB_TYPE' ) ) {
+		if ( 'sqlite' === getenv( 'WP_CLI_TEST_DBTYPE' ) ) {
 			if ( ! is_readable( self::$sqlite_cache_dir . '/sqlite-database-integration/db.copy' ) ) {
 				self::download_sqlite_plugin( self::$sqlite_cache_dir );
 			}
@@ -603,6 +603,12 @@ class FeatureContext implements SnippetAcceptingContext {
 			$this->variables['DB_HOST'] = 'localhost';
 		}
 
+		if ( getenv( 'WP_CLI_TEST_DBTYPE' ) ) {
+			$this->variables['DB_TYPE'] = getenv( 'WP_CLI_TEST_DBTYPE' );
+		} else {
+			$this->variables['DB_TYPE'] = 'mysql';
+		}
+
 		if ( getenv( 'MYSQL_TCP_PORT' ) ) {
 			$this->variables['MYSQL_PORT'] = getenv( 'MYSQL_TCP_PORT' );
 		}
@@ -611,14 +617,12 @@ class FeatureContext implements SnippetAcceptingContext {
 			$this->variables['MYSQL_HOST'] = getenv( 'MYSQL_HOST' );
 		}
 
-		if ( 'sqlite' === getenv( 'DB_TYPE' ) ) {
-			self::$db_type = 'sqlite';
-		}
-
 		self::$db_settings['dbname'] = $this->variables['DB_NAME'];
 		self::$db_settings['dbuser'] = $this->variables['DB_USER'];
 		self::$db_settings['dbpass'] = $this->variables['DB_PASSWORD'];
 		self::$db_settings['dbhost'] = $this->variables['DB_HOST'];
+
+		self::$db_type = $this->variables['DB_TYPE'];
 
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
 

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -34,7 +34,7 @@ class BehatTagsTest extends TestCase {
 	public function test_behat_tags_wp_version_github_token( $env, $expected ) {
 		$env_wp_version   = getenv( 'WP_VERSION' );
 		$env_github_token = getenv( 'GITHUB_TOKEN' );
-		$db_type          = getenv( 'DB_TYPE' );
+		$db_type          = getenv( 'WP_CLI_TEST_DBTYPE' );
 
 		putenv( 'WP_VERSION' );
 		putenv( 'GITHUB_TOKEN' );
@@ -138,7 +138,7 @@ class BehatTagsTest extends TestCase {
 
 	public function test_behat_tags_extension() {
 		$env_github_token = getenv( 'GITHUB_TOKEN' );
-		$db_type          = getenv( 'DB_TYPE' );
+		$db_type          = getenv( 'WP_CLI_TEST_DBTYPE' );
 
 		putenv( 'GITHUB_TOKEN' );
 

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -79,11 +79,11 @@ if ( $wp_version && in_array( $wp_version, array( 'nightly', 'trunk' ), true ) )
 	$skip_tags[] = '@broken-trunk';
 }
 
-if ( 'sqlite' === getenv( 'DB_TYPE' ) ) {
+if ( 'sqlite' === getenv( 'WP_CLI_TEST_DBTYPE' ) ) {
 	$skip_tags[] = '@require-mysql';
 }
 
-if ( 'sqlite' !== getenv( 'DB_TYPE' ) ) {
+if ( 'sqlite' !== getenv( 'WP_CLI_TEST_DBTYPE' ) ) {
 	$skip_tags[] = '@require-sqlite';
 }
 


### PR DESCRIPTION
PR #181 added logic to detect an environment variable named `DB_TYPE` that allows to switch the database engine used for Behat testing from MySQL to SQLite.

This PR renames the environment variable `DB_TYPE` to `WP_CLI_TEST_DBTYPE`, because:
- `DB_TYPE` is a generic environment variable that is actively used in many other systems, and this could lead to weird behavior where unrelated projects like a JS+MongoDB app being developed on the same machine directly impact local testing for WP-CLI.
- all other configurable WP-CLI test database settings are available via `WP_CLI_TEST_DB*` environment variables to configure Behat.