### PR TITLE
SQLite: fix `wp-config.php` creation

### DIFF
--- a/features/testing.feature
+++ b/features/testing.feature
@@ -26,18 +26,18 @@ Feature: Test that WP-CLI loads.
 
   @require-sqlite
   Scenario: Uses SQLite
-  Given a WP install
-  When I run `wp eval 'echo DB_ENGINE;'`
-  Then STDOUT should contain:
-    """
-    sqlite
-    """
+    Given a WP install
+    When I run `wp eval 'echo DB_ENGINE;'`
+    Then STDOUT should contain:
+      """
+      sqlite
+      """
 
   @require-mysql
   Scenario: Uses MySQL
-  Given a WP install
-  When I run `wp eval 'var_export( defined("DB_ENGINE") );'`
-  Then STDOUT should be:
-    """
-    false
-    """
+    Given a WP install
+    When I run `wp eval 'var_export( defined("DB_ENGINE") );'`
+    Then STDOUT should be:
+      """
+      false
+      """

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1034,9 +1034,7 @@ class FeatureContext implements SnippetAcceptingContext {
 			$this->proc( 'wp core install', $install_args, $subdir )->run_check();
 
 			if ( $install_cache_path ) {
-				if ( ! file_exists( $install_cache_path ) ) {
-					mkdir( $install_cache_path );
-				}
+				mkdir( $install_cache_path );
 
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -951,7 +951,6 @@ class FeatureContext implements SnippetAcceptingContext {
 		if ( 'sqlite' === self::$db_type ) {
 			self::copy_dir( self::$sqlite_cache_dir, $dest_dir . '/wp-content/plugins' );
 			self::configure_sqlite( $dest_dir );
-
 		}
 	}
 
@@ -1012,10 +1011,11 @@ class FeatureContext implements SnippetAcceptingContext {
 			'skip-email'     => true,
 		];
 
+		$run_dir            = '' !== $subdir ? ( $this->variables['RUN_DIR'] . "/$subdir" ) : $this->variables['RUN_DIR'];
 		$install_cache_path = '';
+
 		if ( self::$install_cache_dir ) {
 			$install_cache_path = self::$install_cache_dir . '/install_' . md5( implode( ':', $install_args ) . ':subdir=' . $subdir );
-			$run_dir            = '' !== $subdir ? ( $this->variables['RUN_DIR'] . "/$subdir" ) : $this->variables['RUN_DIR'];
 		}
 
 		if ( $install_cache_path && file_exists( $install_cache_path ) ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -978,7 +978,9 @@ class FeatureContext implements SnippetAcceptingContext {
 		}
 
 		error_log( 'Creating wp-config.php in Run Dir: ' . $run_dir );
-		error_log( 'Config Cache Path: ' . $config_cache_path );
+		error_log( 'Config Cache Path: ' . $config_cache_path . ' ' . file_exists( $config_cache_path ) );
+
+		error_log( print_r( scandir( $run_dir ), true ) );
 
 		if ( $config_cache_path && file_exists( $config_cache_path ) ) {
 			copy( $config_cache_path, $run_dir . '/wp-config.php' );
@@ -988,6 +990,8 @@ class FeatureContext implements SnippetAcceptingContext {
 				copy( $run_dir . '/wp-config.php', $config_cache_path );
 			}
 		}
+
+		error_log( print_r( scandir( $run_dir ), true ) );
 	}
 
 	public function install_wp( $subdir = '' ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1018,8 +1018,22 @@ class FeatureContext implements SnippetAcceptingContext {
 			$install_cache_path = self::$install_cache_dir . '/install_' . md5( implode( ':', $install_args ) . ':subdir=' . $subdir );
 		}
 
+		error_log( 'Install Cache Dir: ' . self::$install_cache_dir );
+		error_log( 'Cache Dir: ' . self::$cache_dir );
+		error_log( print_r( scandir( self::$cache_dir ), true ) );
+		error_log( 'SQLite Cache Dir: ' . self::$sqlite_cache_dir );
+		error_log( print_r( scandir( self::$sqlite_cache_dir ), true ) );
+		error_log( 'Run Dir: ' . $run_dir );
+		error_log( print_r( scandir( $run_dir ), true ) );
+
 		if ( $install_cache_path && file_exists( $install_cache_path ) ) {
+			error_log( 'Install Cache Dir: ' . $install_cache_path );
+			error_log( print_r( scandir( $install_cache_path ), true ) );
+			error_log( print_r( scandir( $install_cache_path . '/wp-content' ), true ) );
+
 			self::copy_dir( $install_cache_path, $run_dir );
+
+			error_log( print_r( scandir( $run_dir ), true ) );
 
 			// This is the sqlite equivalent of restoring a database dump in MySQL
 			if ( 'sqlite' === self::$db_type ) {
@@ -1028,6 +1042,9 @@ class FeatureContext implements SnippetAcceptingContext {
 				self::run_sql( 'mysql --no-defaults', [ 'execute' => "source {$install_cache_path}.sql" ], true /*add_database*/ );
 			}
 		} else {
+			error_log( '$subdir: ' . $subdir );
+			error_log( print_r( scandir( $subdir ), true ) );
+
 			$this->proc( 'wp core install', $install_args, $subdir )->run_check();
 			if ( $install_cache_path ) {
 				mkdir( $install_cache_path );

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1019,6 +1019,7 @@ class FeatureContext implements SnippetAcceptingContext {
 		}
 
 		error_log( 'Install Cache Dir: ' . self::$install_cache_dir );
+		error_log( 'Install Cache Path: ' . $install_cache_path );
 		error_log( 'Cache Dir: ' . self::$cache_dir );
 		error_log( print_r( scandir( self::$cache_dir ), true ) );
 		error_log( 'SQLite Cache Dir: ' . self::$sqlite_cache_dir );
@@ -1033,6 +1034,8 @@ class FeatureContext implements SnippetAcceptingContext {
 
 			self::copy_dir( $install_cache_path, $run_dir );
 
+			error_log( 'Run Dir after Copy:' );
+
 			error_log( print_r( scandir( $run_dir ), true ) );
 
 			// This is the sqlite equivalent of restoring a database dump in MySQL
@@ -1043,11 +1046,18 @@ class FeatureContext implements SnippetAcceptingContext {
 			}
 		} else {
 			error_log( '$subdir: ' . $subdir );
-			error_log( print_r( scandir( $subdir ), true ) );
+			if ( $subdir ) {
+				error_log( print_r( scandir( $subdir ), true ) );
+			}
 
-			$this->proc( 'wp core install', $install_args, $subdir )->run_check();
+			$result = $this->proc( 'wp core install', $install_args, $subdir )->run_check();
+			error_log( $result->stderr );
+			error_log( $result->stdout );
 			if ( $install_cache_path ) {
-				mkdir( $install_cache_path );
+				if ( ! file_exists( $install_cache_path ) ) {
+					mkdir( $install_cache_path );
+				}
+
 				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
 
 				if ( 'mysql' === self::$db_type ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -967,6 +967,9 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		$params['skip-salts'] = true;
 
+		// Do not check database connection as we might be running SQLite and the check would fail.
+		$params['skip-check'] = true;
+
 		if ( false !== $extra_php ) {
 			$params['extra-php'] = $extra_php;
 		}

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -978,14 +978,17 @@ class FeatureContext implements SnippetAcceptingContext {
 		}
 
 		error_log( 'Creating wp-config.php in Run Dir: ' . $run_dir );
-		error_log( 'Config Cache Path: ' . $config_cache_path . ' ' . file_exists( $config_cache_path ) );
+		error_log( 'Config Cache Path: ' . $config_cache_path . ' ' . (int) file_exists( $config_cache_path ) );
 
 		error_log( print_r( scandir( $run_dir ), true ) );
 
 		if ( $config_cache_path && file_exists( $config_cache_path ) ) {
 			copy( $config_cache_path, $run_dir . '/wp-config.php' );
 		} else {
-			$this->proc( 'wp config create', $params, $subdir )->run_check();
+			$result = $this->proc( 'wp config create', $params, $subdir )->run_check();
+			error_log( 'Running wp config create ' . Utils\assoc_args_to_str( $params ) . ' in Run Dir:' .  $run_dir );
+			error_log( $result->stderr );
+			error_log( $result->stdout );
 			if ( $config_cache_path && file_exists( $run_dir . '/wp-config.php' ) ) {
 				copy( $run_dir . '/wp-config.php', $config_cache_path );
 			}

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -936,7 +936,12 @@ class FeatureContext implements SnippetAcceptingContext {
 			mkdir( $dest_dir );
 		}
 
+		error_log( 'Copy WP from Cache Dir to Run Dir ' . $dest_dir );
+		error_log( print_r( scandir( $dest_dir ), true ) );
+
 		self::copy_dir( self::$cache_dir, $dest_dir );
+
+		error_log( print_r( scandir( $dest_dir ), true ) );
 
 		if ( ! is_dir( $dest_dir . '/wp-content/mu-plugins' ) ) {
 			mkdir( $dest_dir . '/wp-content/mu-plugins' );
@@ -971,6 +976,9 @@ class FeatureContext implements SnippetAcceptingContext {
 		if ( self::$install_cache_dir ) {
 			$config_cache_path = self::$install_cache_dir . '/config_' . md5( implode( ':', $params ) . ':subdir=' . $subdir );
 		}
+
+		error_log( 'Creating wp-config.php in Run Dir: ' . $run_dir );
+		error_log( 'Config Cache Path: ' . $config_cache_path );
 
 		if ( $config_cache_path && file_exists( $config_cache_path ) ) {
 			copy( $config_cache_path, $run_dir . '/wp-config.php' );

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -978,7 +978,6 @@ class FeatureContext implements SnippetAcceptingContext {
 		if ( $config_cache_path && file_exists( $config_cache_path ) ) {
 			copy( $config_cache_path, $run_dir . '/wp-config.php' );
 		} else {
-			// TODO: Fail scenario if wp-config.php cannot be written.
 			$this->proc( 'wp config create', $params, $subdir )->run_check();
 			if ( $config_cache_path && file_exists( $run_dir . '/wp-config.php' ) ) {
 				copy( $run_dir . '/wp-config.php', $config_cache_path );

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -984,7 +984,6 @@ class FeatureContext implements SnippetAcceptingContext {
 				copy( $run_dir . '/wp-config.php', $config_cache_path );
 			}
 		}
-
 	}
 
 	public function install_wp( $subdir = '' ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -962,8 +962,10 @@ class FeatureContext implements SnippetAcceptingContext {
 
 		$params['skip-salts'] = true;
 
-		// Do not check database connection as we might be running SQLite and the check would fail.
-		$params['skip-check'] = true;
+		// Do not check database connection if running SQLite as the check would fail.
+		if ( 'sqlite' === self::$db_type ) {
+			$params['skip-check'] = true;
+		}
 
 		if ( false !== $extra_php ) {
 			$params['extra-php'] = $extra_php;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

`wp config create` by default checks the database connection when trying to create the `wp-config.php` file, and uses `die()`when the connection fails. This happens on CI because there is no MySQL server running.

https://github.com/wp-cli/config-command/blob/ca25b73e798657ac1846c99b96d3ae8d22be4f34/src/Config_Command.php#L159-L171

