### PR TITLE
SQLite: Support custom wp-content directory

### DIFF
--- a/features/testing.feature
+++ b/features/testing.feature
@@ -41,3 +41,14 @@ Feature: Test that WP-CLI loads.
       """
       false
       """
+
+  @require-sqlite
+  Scenario: Custom wp-content directory
+    Given a WP install
+    And a custom wp-content directory
+
+    When I run `wp eval 'echo DB_ENGINE;'`
+    Then STDOUT should contain:
+      """
+      sqlite
+      """

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -176,6 +176,19 @@ trait GivenStepDefinitions {
 		);
 
 		file_put_contents( $wp_config_path, $wp_config_code );
+
+		if ( 'sqlite' === self::$db_type ) {
+			$db_dropin = $this->variables['RUN_DIR'] . '/my-content/db.php';
+
+			/* similar to https://github.com/WordPress/sqlite-database-integration/blob/3306576c9b606bc23bbb26c15383fef08e03ab11/activate.php#L95 */
+			$file_contents = str_replace(
+				'plugins/',
+				'../my-plugins/',
+				file_get_contents( $db_dropin )
+			);
+
+			file_put_contents( $db_dropin, $file_contents );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Some other commands' tests have tests using a custom wp-content directory. This change ensures those tests pass when running with SQLite.

Adds test coverage.

