### PR TITLE
Allow running Behat tests in parallel

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -5,3 +5,5 @@ default:
         - WP_CLI\Tests\Context\FeatureContext
       paths:
         - features
+  extensions:
+    Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~

--- a/bin/run-behat-tests-parallel
+++ b/bin/run-behat-tests-parallel
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
+SOURCE="${BASH_SOURCE[0]}"
+
+# Resolve $SOURCE until the file is no longer a symlink.
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # If $SOURCE was a relative symlink, we need to resolve it relative to the
+  # path where the symlink file was located.
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+export WP_CLI_TESTS_ROOT
+
+"$WP_CLI_TESTS_ROOT"/bin/run-behat-tests --list-scenarios "$@" | vendor/liuggio/fastest/fastest "$WP_CLI_TESTS_ROOT/bin/run-behat-tests {}"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=5.6",
         "behat/behat": "^3.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
+        "liuggio/fastest": "^1.11",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
@@ -59,6 +60,7 @@
         "bin/install-package-tests",
         "bin/rerun-behat-tests",
         "bin/run-behat-tests",
+        "bin/run-behat-tests-parallel",
         "bin/run-linter-tests",
         "bin/run-php-unit-tests",
         "bin/run-phpcs-tests",
@@ -66,6 +68,7 @@
     ],
     "scripts": {
         "behat": "run-behat-tests",
+        "behat-parallel": "run-behat-tests-parallel",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.6",
         "behat/behat": "^3.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
-        "liuggio/fastest": "^1.11",
+        "liuggio/fastest": "^v1.6.1",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "^9.3.5",

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -960,6 +960,11 @@ class FeatureContext implements SnippetAcceptingContext {
 		// Replaces all characters that are not alphanumeric or an underscore into an underscore.
 		$params['dbprefix'] = $subdir ? preg_replace( '#[^a-zA-Z\_0-9]#', '_', $subdir ) : 'wp_';
 
+		// If running tests in parallel, use different prefixes.
+		if ( getenv( 'ENV_TEST_CHANNEL' ) ) {
+			$params['dbprefix'] = 'wp_cli_test_' . (int) getenv( 'ENV_TEST_CHANNEL' ) . '_' . $params['dbprefix'];
+		}
+
 		$params['skip-salts'] = true;
 
 		// Do not check database connection if running SQLite as the check would fail.
@@ -1019,8 +1024,13 @@ class FeatureContext implements SnippetAcceptingContext {
 		$run_dir            = '' !== $subdir ? ( $this->variables['RUN_DIR'] . "/$subdir" ) : $this->variables['RUN_DIR'];
 		$install_cache_path = '';
 
+		$channel = (int) getenv( 'ENV_TEST_CHANNEL' );
+		if ( ! $channel ) {
+			$channel = 1;
+		}
+
 		if ( self::$install_cache_dir ) {
-			$install_cache_path = self::$install_cache_dir . '/install_' . md5( implode( ':', $install_args ) . ':subdir=' . $subdir );
+			$install_cache_path = self::$install_cache_dir . '/install_' . md5( implode( ':', $install_args ) . ':subdir=' . $subdir . ':channel=' . $channel );
 		}
 
 		if ( $install_cache_path && file_exists( $install_cache_path ) ) {


### PR DESCRIPTION
This is probably not the right repo for this (where is the source of truth?), but proves that running Behat tests in parallel is possible. Convenient if you want to run all tests locally quickly.

Usage: `composer behat-parallel`

Uses different table prefixes and cache dirs for each process.

Not fully tested, but wanted to get the idea across.

Fixes https://github.com/wp-cli/wp-cli/issues/3814