### PR TITLE
Fix SQLite mu-plugins usage with composer installs

### DIFF
--- a/features/testing.feature
+++ b/features/testing.feature
@@ -52,3 +52,13 @@ Feature: Test that WP-CLI loads.
       """
       sqlite
       """
+
+  @require-sqlite
+  Scenario: Composer installation
+    Given a WP install with Composer
+
+    When I run `wp eval 'echo DB_ENGINE;'`
+    Then STDOUT should contain:
+      """
+      sqlite
+      """

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1091,7 +1091,12 @@ class FeatureContext implements SnippetAcceptingContext {
 			'skip-email'     => true,
 		];
 
+		if ( ! is_dir( $this->variables['RUN_DIR'] . '/WordPress/wp-content/mu-plugins' ) ) {
+			mkdir( $this->variables['RUN_DIR'] . '/WordPress/wp-content/mu-plugins' );
+		}
+
 		if ( 'sqlite' === self::$db_type ) {
+			mkdir( $this->variables['RUN_DIR'] . '/WordPress/wp-content/mu-plugins/sqlite-database-integration' );
 			self::copy_dir( self::$sqlite_cache_dir, $this->variables['RUN_DIR'] . '/WordPress/wp-content/mu-plugins' );
 			self::configure_sqlite( $this->variables['RUN_DIR'] . '/WordPress' );
 		}


### PR DESCRIPTION
Adds a test in this repo so we don’t have to find out by looking at other repos

Note:

I accidentally found out that the following doesn't work:

```
Given a WP install with Composer
And a custom wp-content directory
```

That's because of a different `RUN_DIR`, but this scenario is never tested and probably doesn't need to be. And it's not isolated to SQLite either so would warrant its own PR.

Related https://github.com/wp-cli/wp-cli/issues/5859