### PR TITLE
Lock version of SQLite plugin to v2.1.3

### DIFF
--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -28,7 +28,7 @@ if [ -n "${WP_CLI_TEST_DBHOST}" ]; then
 	if [ -n "${PORT}" ]; then
 		# If the port is not numeric, then we assume it is a socket path.
 		if is_numeric "${PORT}"; then
-			HOST_STRING="${HOST_STRING} --port${PORT} --protocol=tcp"
+			HOST_STRING="${HOST_STRING} --port=${PORT} --protocol=tcp"
 		else
 			HOST_STRING="${HOST_STRING} --socket=${PORT} --protocol=socket"
 		fi

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -334,7 +334,7 @@ class FeatureContext implements SnippetAcceptingContext {
 	* for use in subsequent WordPress copies
 	*/
 	private static function download_sqlite_plugin( $dir ) {
-		$download_url      = 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
+		$download_url      = 'https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/v2.1.3.zip';
 		$download_location = $dir . '/sqlite-database-integration.zip';
 
 		if ( ! is_dir( $dir ) ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -364,6 +364,13 @@ class FeatureContext implements SnippetAcceptingContext {
 			$error_message = $zip->getStatusString();
 			throw new RuntimeException( sprintf( 'Failed to open the zip file: %s', $error_message ) );
 		}
+
+		// For the release downloaded from GitHub, the unzipped folder will contain the version number.
+		// We're renaming the folder here for consistency's sake.
+		rename(
+			$dir . '/sqlite-database-integration-2.1.3/',
+			$dir . '/sqlite-database-integration/'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Version 2.1.4 of the SQLite plugin contains a syntax error on PHP < 7.3. This PR locks the plugin version to 2.1.3 for now to make tests pass.

See https://github.com/WordPress/sqlite-database-integration/pull/62