### PR TITLE
Add mapped_socket_folder to allow for socket-based DB testing

### DIFF
--- a/utils/mapped_socket_folder/README.md
+++ b/utils/mapped_socket_folder/README.md
@@ -1,0 +1,3 @@
+This folder serves as a mount point to allow database servers running in Docker container to mount their socket file into the host system for testing socket-based connections.
+
+See https://github.com/wp-cli/config-command/pull/171


### PR DESCRIPTION
To be able to run tests against multiple DB versions for https://github.com/wp-cli/config-command/pull/171, we need a way of mounting a socket file within a MySQL Docker container into the surrouding host system.

This PR adds a folder that will always exist so that a bind mount can be established to mount the folder containing the socket file (the socket file cannot be mounted directly).