### PR TITLE
Add socket env to internal variables

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -626,6 +626,10 @@ class FeatureContext implements SnippetAcceptingContext {
 			$this->variables['MYSQL_HOST'] = getenv( 'MYSQL_HOST' );
 		}
 
+		if ( getenv( 'WP_CLI_TEST_DBSOCKET' ) ) {
+			$this->variables['DB_SOCKET'] = getenv( 'WP_CLI_TEST_DBSOCKET' );
+		}
+
 		self::$db_settings['dbname'] = $this->variables['DB_NAME'];
 		self::$db_settings['dbuser'] = $this->variables['DB_USER'];
 		self::$db_settings['dbpass'] = $this->variables['DB_PASSWORD'];

--- a/utils/mapped_socket_folder/README.md
+++ b/utils/mapped_socket_folder/README.md
@@ -1,3 +1,0 @@
-This folder serves as a mount point to allow database servers running in Docker container to mount their socket file into the host system for testing socket-based connections.
-
-See https://github.com/wp-cli/config-command/pull/171


### PR DESCRIPTION
This PR looks for the `WP_CLI_TEST_DBSOCKET` environment variables and maps it to the internal Behat variable `DB_SOCKET` so it can be used from within tests.