### PR TITLE
Avoid PHP warnings on missing variables

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -700,13 +700,17 @@ class FeatureContext implements SnippetAcceptingContext {
 	 * Replace variables callback.
 	 */
 	private function replace_var( $matches ) {
-		$cmd = $matches[0];
+		$str = $matches[0];
 
 		foreach ( array_slice( $matches, 1 ) as $key ) {
-			$cmd = str_replace( '{' . $key . '}', $this->variables[ $key ], $cmd );
+			$str = str_replace(
+				'{' . $key . '}',
+				array_key_exists( $key, $this->variables ) ? $this->variables[ $key ] : '',
+				$str
+			);
 		}
 
-		return $cmd;
+		return $str;
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/wp-cli/automated-tests/actions/runs/7287895211/job/19859462619#step:14:203