### PR TITLE
Add `wp-versions-data-fetcher` workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
+[*.yml]
+quote_type = single
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.github/workflows/wp-versions-data-fetcher.yml
+++ b/.github/workflows/wp-versions-data-fetcher.yml
@@ -71,6 +71,7 @@ jobs:
               echo "::error::Failed to fetch WP versions from $WP_ORG_API_URL after $MAX_RETRIES attempts"
               exit 1
             fi
+            echo "Retrying in $BACKOFF seconds"
             sleep $BACKOFF
             BACKOFF=$((BACKOFF * 2))
           done

--- a/.github/workflows/wp-versions-data-fetcher.yml
+++ b/.github/workflows/wp-versions-data-fetcher.yml
@@ -1,0 +1,125 @@
+---
+name: WP Versions Data Fetcher
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      max_retries:
+        description: 'Max retries to fetch data from WPOrg API'
+        default: 3
+        required: false
+        type: number
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  ARTIFACTS_BRANCH: 'artifacts'
+  FEATURE_BRANCH: 'sync-wp-versions'
+  FILE_PATH: 'wp-versions.json'
+  MAX_RETRIES: ${{ inputs.max_retries || 3 }}
+  WP_ORG_API_URL: 'https://api.wordpress.org/core/stable-check/1.0/'
+
+jobs:
+  fetch-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ env.ARTIFACTS_BRANCH }}
+
+      - name: Check if feature branch exists
+        id: remote-branch
+        run: |
+          echo "exists=$([[ -z $(git ls-remote --heads origin ${{ env.FEATURE_BRANCH }}) ]] && echo "0" || echo "1")" >> $GITHUB_OUTPUT
+
+      - name: Create feature branch
+        if: steps.remote-branch.outputs.exists == '0'
+        run: |
+          git checkout -b ${{ env.FEATURE_BRANCH }}
+
+      - name: Checkout feature branch
+        if: steps.remote-branch.outputs.exists == '1'
+        run: |
+          git fetch --all --prune
+          git checkout ${{ env.FEATURE_BRANCH }}
+          git pull --no-rebase
+
+      - name: Fetch WP Versions
+        run: |
+          BACKOFF=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            echo "Fetching WP versions, attempt $i"
+            RES_CODE=$(curl -sL -w "%{http_code}" $WP_ORG_API_URL -o /tmp/wp-versions.json)
+            if [ $RES_CODE -eq 200 ]; then
+              mv /tmp/wp-versions.json $FILE_PATH
+              echo "::notice::WP versions data has been fetched successfully."
+              break
+            fi
+            echo "Failed to fetch WP versions, attempt $i"
+            if [ $i -eq $MAX_RETRIES ]; then
+              echo "::error::Failed to fetch WP versions from $WP_ORG_API_URL after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            sleep $BACKOFF
+            BACKOFF=$((BACKOFF * 2))
+          done
+
+      - name: Track modified files
+        id: version-file
+        run: |
+          IS_MODIFIED=$(git ls-files --modified wp-versions.json)
+          if [ -n "$IS_MODIFIED" ]; then
+            DIFF=$(git diff ${{ env.ARTIFACTS_BRANCH }} -- $FILE_PATH)
+            echo "# Modified WP Versions Data" >> $GITHUB_STEP_SUMMARY
+            echo "<details><summary>WP Versions Data Diff</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`diff" >> $GITHUB_STEP_SUMMARY
+            echo "$DIFF" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+            echo "modified=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::WP versions data has not been modified."
+            exit 0
+          fi
+
+      - name: Set git user
+        if: steps.version-file.outputs.modified == 'true'
+        run: |
+          # See: https://api.github.com/users/github-actions[bot]
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit WP Versions Data
+        if: steps.version-file.outputs.modified == 'true'
+        run: |
+          git add $FILE_PATH
+          git commit -m "Update $FILE_PATH on $(date -u)" --signoff
+
+      - name: Push changes
+        if: steps.version-file.outputs.modified == 'true'
+        run: |
+          git push origin ${{ env.FEATURE_BRANCH }}
+
+      - name: Create Pull Request
+        run: |
+          body="## Summary
+          Update WP versions data file with the \`${WP_ORG_API_URL}\` endpoint response."
+          delimiter="${body//$'\n'/'%0A'}"
+          echo "body<<${delimiter}" >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
+          gh pr create --base ${{ env.ARTIFACTS_BRANCH }} --head ${{ env.FEATURE_BRANCH }} --title "Update WP Versions Data" --body "$body" --label "scope:artifacts" || true
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Add workflow to do the following tasks:

- Fetch data from `https://api.wordpress.org/core/stable-check/1.0/` and save it to `wp-versions.json` file.
- Create pull request against the `artifacts` branch in case no active pull requests are present.
- Push changes to the existing PR in case the PR exists.

Partially addresses https://github.com/wp-cli/wp-cli-tests/issues/51
Related: https://github.com/wp-cli/wp-cli/issues/5935

## TODO (before merging this PR in the main branch)
- Create a new orphan branch called `artifacts`.
- Commit empty `wp-versions.json` file and push to the `artifacts` branch. 
- Add required branch protection rules to avoid branch deletion by some automation or person.
- Enable `Allow GitHub Actions to create and approve pull requests` in `Settings > Actions > General`.