### PR TITLE
Add script to resolve semver for `WP_VERSION` env 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ composer.lock
 phpunit.xml
 phpcs.xml
 .phpcs.xml
+.phpunit.result.cache

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -19,11 +19,6 @@ if [[ "$@" == *"--help"* ]]; then
     exit $ret
 fi
 
-# Turn WP_VERSION into an actual number to make sure our tags work correctly.
-if [ "${WP_VERSION-latest}" = "latest" ]; then
-	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
-fi
-
 # To retrieve the WP-CLI tests package root folder, we start with this scripts
 # location.
 SOURCE="${BASH_SOURCE[0]}"

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -39,5 +39,11 @@ export WP_CLI_TESTS_ROOT
 # Generate the tags to apply environment-specific filters.
 BEHAT_TAGS=$(php "$WP_CLI_TESTS_ROOT"/utils/behat-tags.php)
 
+# Resolve WP_VERSION.
+WP_VERSION=$(php "$WP_CLI_TESTS_ROOT"/utils/wp-version-resolver.php)
+export WP_VERSION
+
+echo "Running Behat tests for WordPress $WP_VERSION"
+
 # Run the functional tests.
 vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "$@"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": ">=5.6",
         "behat/behat": "^3.7",
+        "composer/semver": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -63,9 +63,11 @@
 		 so this file does not have to comply with WP naming conventions. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<exclude-pattern>*/utils/behat-tags\.php$</exclude-pattern>
+		<exclude-pattern>*/utils/wp-version-resolver\.php$</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
 		<exclude-pattern>*/utils/behat-tags\.php$</exclude-pattern>
+		<exclude-pattern>*/utils/wp-version-resolver\.php$</exclude-pattern>
 	</rule>
 
 	<!-- This is a procedural stand-alone file that is adding polyfills when

--- a/tests/test-wp-version-resolver.php
+++ b/tests/test-wp-version-resolver.php
@@ -1,0 +1,83 @@
+<?php
+
+use WP_CLI\Utils;
+use WP_CLI\Tests\TestCase;
+
+class WPVersionResolverTest extends TestCase {
+
+	private $temp_file;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->temp_file =  Utils\get_temp_dir() . 'wp-cli-tests-wp-versions.json';
+
+		$fp = fopen( $this->temp_file, 'w' );
+		fwrite( $fp, json_encode( $this->wp_versions_data() ) );
+		fclose( $fp );
+	}
+
+	protected function tear_down() {
+		if ( $this->temp_file && file_exists( $this->temp_file ) ) {
+			unlink( $this->temp_file );
+		}
+
+		parent::tear_down();
+	}
+
+	private function wp_versions_data() {
+		return array(
+			'5.9' => 'insecure',
+			'5.9.1' => 'insecure',
+			'5.9.2' => 'insecure',
+			'6.0' => 'insecure',
+			'6.0.1' => 'insecure',
+			'6.0.2' => 'insecure',
+			'6.1' => 'insecure',
+			'6.1.1' => 'insecure',
+			'6.1.2' => 'insecure',
+			'6.2' => 'insecure',
+			'6.2.1' => 'insecure',
+			'6.2.2' => 'insecure',
+			'6.5' => 'insecure',
+			'6.5.2' => 'latest',
+		);
+	}
+
+	private function data_wp_version_resolver() {
+		return array(
+			array( '5.0', '5.0' ), // Does not match any version. So return as it is.
+			array( '5', '6.5.2' ), // Return the latest major version.
+			array( '5.9', '5.9.2' ), // Return the latest patch version.
+			array( '5.9.1', '5.9.1' ), // Return the exact version.
+			array( '6', '6.5.2' ), // Return the latest minor version.
+			array( '6.0', '6.0.2' ), // Return the latest patch version.
+			array( '6.0.0', '6.0' ), // Return the requested version.
+			array( '', '6.5.2' ), // Return the latest version.
+			array( 'latest', '6.5.2' ), // Return the latest version.
+			array( 'some-mismatched-version', 'some-mismatched-version' ), // Does not match any version. So return as it is.
+			array( '6.5-alpha', '6.5.2' ), // Return the latest version.
+			array( '6.5-beta', '6.5.2' ), // Return the latest version.
+			array( '6.5-rc', '6.5.2' ), // Return the latest version.
+			array( '6.5-nightly', '6.5-nightly' ), // Does not match any version. So return as it is.
+			array( '6.5.0.0', '6.5' ), // Return the latest version.
+			array( '6.5.2.0', '6.5.2' ), // Return the latest version.
+		);
+	}
+
+	/**
+	 * @dataProvider data_wp_version_resolver
+	 */
+	public function test_wp_version_resolver( $env, $expected ) {
+		if ( $env ) {
+			putenv( "WP_VERSION=$env" );
+		}
+
+		$output = exec( 'php ' . dirname( __DIR__ ) . '/utils/wp-version-resolver.php' );
+
+		$this->assertEquals( $expected, $output );
+
+		// Reset the environment variable.
+		putenv( 'WP_VERSION' );
+	}
+}

--- a/utils/wp-version-resolver.php
+++ b/utils/wp-version-resolver.php
@@ -23,12 +23,7 @@ if ( ! file_exists( $wp_versions_file_path ) ) {
 	fclose( $fp );
 }
 
-$wp_versions_json = json_decode( file_get_contents( sys_get_temp_dir() . WP_VERSIONS_JSON_FILE ), true );
-
-if ( empty( $wp_version_env ) ) {
-	echo $wp_version_env;
-	exit( 0 );
-}
+$wp_versions_json = json_decode( file_get_contents( $wp_versions_file_path ), true );
 
 if ( empty( $wp_version_env ) || 'latest' === $wp_version_env ) {
 	$wp_version = array_search( 'latest', $wp_versions_json, true );

--- a/utils/wp-version-resolver.php
+++ b/utils/wp-version-resolver.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Resolve the WP version to use for the tests.
+ */
+
+use Composer\Semver\Semver;
+
+const WP_VERSIONS_JSON_FILE = '/wp-cli-tests-wp-versions.json';
+const WP_VERSIONS_JSON_URL  = 'https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts/wp-versions.json';
+
+$wp_version_env        = getenv( 'WP_VERSION' );
+$wp_versions_file_path = sys_get_temp_dir() . WP_VERSIONS_JSON_FILE;
+
+if ( ! file_exists( $wp_versions_file_path ) ) {
+	$ch = curl_init( WP_VERSIONS_JSON_URL );
+	$fp = fopen( $wp_versions_file_path, 'w' );
+
+	curl_setopt( $ch, CURLOPT_FILE, $fp );
+	curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
+
+	curl_exec( $ch );
+	curl_close( $ch );
+	fclose( $fp );
+}
+
+$wp_versions_json = json_decode( file_get_contents( sys_get_temp_dir() . WP_VERSIONS_JSON_FILE ), true );
+
+if ( empty( $wp_version_env ) ) {
+	echo $wp_version_env;
+	exit( 0 );
+}
+
+if ( empty( $wp_version_env ) || 'latest' === $wp_version_env ) {
+	$wp_version = array_search( 'latest', $wp_versions_json, true );
+
+	if ( empty( $wp_version ) ) {
+		$wp_version = $wp_version_env;
+	}
+
+	echo $wp_version;
+	exit( 0 );
+}
+
+$wp_version    = '';
+$constraint    = '';
+$wp_versions   = array_keys( $wp_versions_json );
+$version_count = count( explode( '.', $wp_version_env ) );
+
+if ( 1 === $version_count ) {
+	$constraint = ">=$wp_version_env"; // Get the latest minor version.
+} elseif ( 2 === $version_count ) {
+	$constraint = "~$wp_version_env.0"; // Get the latest patch version.
+} elseif ( 3 === $version_count ) {
+	$constraint = "=$wp_version_env"; // Get the exact version.
+} else {
+	$constraint = $wp_version_env;
+}
+
+if ( ! class_exists( 'Composer\Semver\Semver' ) ) {
+	require_once __DIR__ . '/../vendor/autoload.php';
+}
+
+try {
+	$wp_satisfied_versions = Semver::satisfiedBy( $wp_versions, $constraint );
+} catch ( Exception $e ) {
+	echo $wp_version_env;
+	exit( 0 );
+}
+
+$wp_version = end( $wp_satisfied_versions );
+echo $wp_version ? : $wp_version_env;


### PR DESCRIPTION
## Summary

THis PR aims to add a script which help to determine the semver for passed `WP_VERSION` env variable. To do so correctly, this script uses `composer/semver` package.

Example cases:

```php
// Input => Output
array( '5.0', '5.0' ), // Does not match any version. So return as it is.
array( '5', '6.5.2' ), // Return the latest major version.
array( '5.9', '5.9.2' ), // Return the latest patch version.
array( '5.9.1', '5.9.1' ), // Return the exact version.
array( '6', '6.5.2' ), // Return the latest minor version.
array( '6.0', '6.0.2' ), // Return the latest patch version.
array( '6.0.0', '6.0' ), // Return the requested version.
array( '', '6.5.2' ), // Return the latest version.
array( 'latest', '6.5.2' ), // Return the latest version.
array( 'some-mismatched-version', 'some-mismatched-version' ), // Does not match any version. So return as it is.
array( '6.5-alpha', '6.5.2' ), // Return the latest version.
array( '6.5-beta', '6.5.2' ), // Return the latest version.
array( '6.5-rc', '6.5.2' ), // Return the latest version.
array( '6.5-nightly', '6.5-nightly' ), // Does not match any version. So return as it is.
array( '6.5.0.0', '6.5' ), // Return the latest version.
array( '6.5.2.0', '6.5.2' ), // Return the latest version.
```