### PR TITLE
Use the latest SQLite version instead of locking it to a specific one

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -334,7 +334,7 @@ class FeatureContext implements SnippetAcceptingContext {
 	* for use in subsequent WordPress copies
 	*/
 	private static function download_sqlite_plugin( $dir ) {
-		$download_url      = 'https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/v2.1.11.zip';
+		$download_url      = 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
 		$download_location = $dir . '/sqlite-database-integration.zip';
 
 		if ( ! is_dir( $dir ) ) {
@@ -364,13 +364,6 @@ class FeatureContext implements SnippetAcceptingContext {
 			$error_message = $zip->getStatusString();
 			throw new RuntimeException( sprintf( 'Failed to open the zip file: %s', $error_message ) );
 		}
-
-		// For the release downloaded from GitHub, the unzipped folder will contain the version number.
-		// We're renaming the folder here for consistency's sake.
-		rename(
-			$dir . '/sqlite-database-integration-2.1.11/',
-			$dir . '/sqlite-database-integration/'
-		);
 	}
 
 	/**


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

In this PR we go back to using the latest version of the SQlite database integration plugin to ensure we always run the most up to date version.

This was discussed in #214 
