### PR TITLE
Bump phpcompatibility requirement to development branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
-        "phpcompatibility/php-compatibility": "^9.3.5",
+        "phpcompatibility/php-compatibility": "dev-develop",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",


### PR DESCRIPTION
As noted in #217 there hasn't been a release of [phpcompatibility](https://github.com/PHPCompatibility/PHPCompatibility/) since 2019 and the current version can't detect PHP 8 specific code. It probably has other useful fixes for earlier versions of PHP that have been applied in the last several years as well.

Fixes #217