### PR TITLE
Tests: Replace `mysql_native_password` with `caching_sha2_password`

### DIFF
--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -76,7 +76,7 @@ done
 install_mysql_db_8_0_plus() {
 	set -ex
 	mysql -e "CREATE DATABASE IF NOT EXISTS \`${TEST_DB}\`;" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
-	mysql -e "CREATE USER IF NOT EXISTS \`${TEST_USER}\`@'%' IDENTIFIED WITH mysql_native_password BY '${TEST_PASSWORD}'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "CREATE USER IF NOT EXISTS \`${TEST_USER}\`@'%' IDENTIFIED WITH caching_sha2_password BY '${TEST_PASSWORD}'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
 	mysql -e "GRANT ALL PRIVILEGES ON \`${TEST_DB}\`.* TO '${TEST_USER}'@'%'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
 	mysql -e "GRANT ALL PRIVILEGES ON \`${TEST_DB}_scaffold\`.* TO '${TEST_USER}'@'%'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
 }


### PR DESCRIPTION
Bug Ticket: https://github.com/wp-cli/ideas/issues/194

This PR should fix the `composer prepare-tests` command issue on the [wp-cli-dev](https://github.com/wp-cli/wp-cli-dev) repo existing for anyone running sql version 8.0.4+