### PR TITLE
PHPUnit: convert deprecations to exceptions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,10 @@
 <phpunit
 	bootstrap="tests/bootstrap.php"
 	colors="true"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="default">


### PR DESCRIPTION
Since PHPUnit 9.5.10 and 8.5.21, PHP deprecations are no longer converted to exceptions by default (`convertDeprecationsToExceptions="true"` can be configured to enable this).

This commit reverts PHPUnit to the previous behaviour by adding `convertDeprecationsToExceptions="true"` to the PHPUnit configuration. It also adds the other related directives for consistency.

See similar change in core: https://github.com/WordPress/wordpress-develop/commit/7c2b54e0275201a07c145de5c705545ef58ebda7