### PR TITLE
PHPUnit: Fix regex in bootstrap file

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,7 +43,7 @@ function wpcli_tests_include_config( array $config_filenames = [] ) {
 	if ( $config_filename ) {
 		$config  = file_get_contents( $config_filename );
 		$matches = null;
-		$pattern = '/bootstrap="(?P<bootstrap>.*)"/';
+		$pattern = '/bootstrap="(?P<bootstrap>[^"]*)"/';
 		$result  = preg_match( $pattern, $config, $matches );
 		if ( isset( $matches['bootstrap'] ) && file_exists( $matches['bootstrap'] ) ) {
 			include_once PACKAGE_ROOT . '/' . $matches['bootstrap'];


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

The current regex doesn't work if all the attributes in the PHPUnit config file are on one line.
