### PR TITLE
Explicitly provide `$escape` to `str_getcsv`

### DIFF
--- a/src/Context/Support.php
+++ b/src/Context/Support.php
@@ -174,8 +174,10 @@ trait Support {
 	protected function check_that_csv_string_contains_values( $actual_csv, $expected_csv ) {
 		$actual_csv = array_map(
 			static function ( $str ) {
-				return str_getcsv( $str, ',', '"', "\\" );
-			}, explode( PHP_EOL, $actual_csv ) );
+				return str_getcsv( $str, ',', '"', '\\' );
+			},
+			explode( PHP_EOL, $actual_csv )
+		);
 
 		if ( empty( $actual_csv ) ) {
 			return false;

--- a/src/Context/Support.php
+++ b/src/Context/Support.php
@@ -172,7 +172,10 @@ trait Support {
 	 * @return bool   Whether $actual_csv contains $expected_csv
 	 */
 	protected function check_that_csv_string_contains_values( $actual_csv, $expected_csv ) {
-		$actual_csv = array_map( 'str_getcsv', explode( PHP_EOL, $actual_csv ) );
+		$actual_csv = array_map(
+			static function ( $str ) {
+				return str_getcsv( $str, ',', '"', "\\" );
+			}, explode( PHP_EOL, $actual_csv ) );
 
 		if ( empty( $actual_csv ) ) {
 			return false;


### PR DESCRIPTION
Addresses the following test failure on PHP 8.4: https://github.com/wp-cli/wp-cli/actions/runs/11656752489/job/32453448665#step:11:76

```
str_getcsv(): the $escape parameter must be provided as its default value will change in vendor/wp-cli/wp-cli-tests/src/Context/Support.php line 175
```

As per the [documentation](https://www.php.net/manual/en/function.str-getcsv.php):

> Warning
When escape is set to anything other than an empty string ("") it can result in CSV that is not compliant with [» RFC 4180](http://www.faqs.org/rfcs/rfc4180) or unable to survive a roundtrip through the PHP CSV functions. The default for escape is "\\" so it is recommended to set it to the empty string explicitly. The default value will change in a future version of PHP, no earlier than PHP 9.0.