### PR TITLE
Allow running Behat tests in parallel

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -5,3 +5,5 @@ default:
         - WP_CLI\Tests\Context\FeatureContext
       paths:
         - features
+  extensions:
+    DMarynicz\BehatParallelExtension\Extension: ~

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -19,6 +19,12 @@ if [[ "$@" == *"--help"* ]]; then
     exit $ret
 fi
 
+PARALLEL=""
+if [[ -n "${BEHAT_PARALLEL}" ]]; then
+    PARALLEL="--parallel"
+fi
+
+
 # Turn WP_VERSION into an actual number to make sure our tags work correctly.
 if [ "${WP_VERSION-latest}" = "latest" ]; then
 	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
@@ -45,4 +51,4 @@ export WP_CLI_TESTS_ROOT
 BEHAT_TAGS=$(php "$WP_CLI_TESTS_ROOT"/utils/behat-tags.php)
 
 # Run the functional tests.
-vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "$@"
+vendor/bin/behat "${PARALLEL}" --format progress "$BEHAT_TAGS" --strict "$@"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=5.6",
         "behat/behat": "^3.7",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
+        "dmarynicz/behat-parallel-extension": "^1.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "dev-develop",


### PR DESCRIPTION
Allows one to set `BEHAT_PARALLEL` env var to run tests in parallel.

Example:

BEHAT_PARALLEL=1 WP_CLI_TEST_DBTYPE=sqlite composer behat

Motivation:
  Was working on `extension-command` and tests take [7 minutes](https://github.com/wp-cli/extension-command/pull/438/checks). Running in parallel allows for a dramatic decrease in execution time and therefore way less GitHub Actions minutes and electricity will be used. 
  
  Added as an ENV var as not all repos may have the appropriate isolation to run in parallel at the moment.