### PR TITLE
Allow collecting PHPUnit coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpunit.xml
 phpcs.xml
 .phpcs.xml
 .phpunit.result.cache
+build/logs

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,10 @@
 			<directory prefix="Test" suffix=".php">tests/tests</directory>
 		</testsuite>
 	</testsuites>
+
+	<coverage processUncoveredFiles="false">
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
Fixes a currently failing code coverage job because the PHPUnit config is outdated.

See https://github.com/wp-cli/wp-cli/issues/6035

See #234