### PR TITLE
Fix HTTP mocking test / Requests v1 support

### DIFF
--- a/features/http-mocking.feature
+++ b/features/http-mocking.feature
@@ -77,10 +77,11 @@ Feature: HTTP request mocking
     ]
     """
 
-    When I run `wp cli check-update`
-    Then STDOUT should be a table containing rows:
-      | version | update_type | package_url |
-      | 999.9.9 | major       | https://github.com/wp-cli/wp-cli/releases/download/v999.9.9/wp-cli-999.9.9.phar |
+    When I try `wp cli check-update --format=csv`
+    Then STDOUT should contain:
+    """
+    999.9.9,major,https://github.com/wp-cli/wp-cli/releases/download/v999.9.9/wp-cli-999.9.9.phar,available
+    """
 
   Scenario: Mock HTTP request in WordPress
     Given a WP install

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -201,11 +201,8 @@ WP_CLI::add_wp_hook(
 							'url'     => \$url,
 							'headers' => array(),
 							'data'    => array(),
-							'options' => array_merge(
-								Requests::OPTION_DEFAULTS,
-								array(
-									'hooks' => new Requests_Hooks(),
-								)
+							'options' => array(
+								'hooks' => new Requests_Hooks(),
 							),
 						)
 					);

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -113,12 +113,11 @@ FILE;
 
 		$mock_file_contents = <<<FILE
 <?php
-use WpOrg\Requests\Hooks;
-use WpOrg\Requests\Transport;
-use WpOrg\Requests\Transport\Curl;
-use WpOrg\Requests\Requests;
+/**
+ * HTTP request mocking supporting both Requests v1 and v2.
+ */
 
-class WP_CLI_Tests_Mock_Requests_Transport implements Transport {
+trait WP_CLI_Tests_Mock_Requests_Trait {
 	public function request( \$url, \$headers = array(), \$data = array(), \$options = array() ) {
 		\$mocked_requests = $mocked_requests;
 
@@ -133,7 +132,11 @@ class WP_CLI_Tests_Mock_Requests_Transport implements Transport {
 			}
 		}
 
-		return (new Curl())->request( \$url, \$headers, \$data, \$options );
+		if ( class_exists( 'Requests_Transport_cURL' ) ) {
+			return ( new Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
+		}
+
+		return ( new WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
 	}
 
 	public function request_multiple( \$requests, \$options ) {
@@ -142,6 +145,16 @@ class WP_CLI_Tests_Mock_Requests_Transport implements Transport {
 
 	public static function test( \$capabilities = array() ) {
 		return true;
+	}
+}
+
+if ( interface_exists( 'Requests_Transport' ) ) {
+	class WP_CLI_Tests_Mock_Requests_Transport implements Requests_Transport {
+		use WP_CLI_Tests_Mock_Requests_Trait;
+	}
+} else {
+	class WP_CLI_Tests_Mock_Requests_Transport implements WpOrg\Requests\Transport {
+		use WP_CLI_Tests_Mock_Requests_Trait;
 	}
 }
 
@@ -165,20 +178,39 @@ WP_CLI::add_wp_hook(
 				if ( false !== \$pos ) {
 					\$response = substr( \$response, 0, \$pos ) . "\r\n\r\n" . substr( \$response, \$pos + 2 );
 				}
-				Requests::parse_multiple(
-					\$response,
-					array(
-						'url'     => \$url,
-						'headers' => array(),
-						'data'    => array(),
-						'options' => array_merge(
-							Requests::OPTION_DEFAULTS,
-							array(
-								'hooks' => new Hooks(),
-							)
-						),
-					)
-				);
+
+				if ( class_exists( '\Requests' ) ) {
+					\Requests::parse_multiple(
+						\$response,
+						array(
+							'url'     => \$url,
+							'headers' => array(),
+							'data'    => array(),
+							'options' => array_merge(
+								Requests::OPTION_DEFAULTS,
+								array(
+									'hooks' => new Requests_Hooks(),
+								)
+							),
+						)
+					);
+				} else {
+					WpOrg\Requests\Requests::parse_multiple(
+						\$response,
+						array(
+							'url'     => \$url,
+							'headers' => array(),
+							'data'    => array(),
+							'options' => array_merge(
+								Requests::OPTION_DEFAULTS,
+								array(
+									'hooks' => new WpOrg\Requests\Hooks(),
+								)
+							),
+						)
+					);
+				}
+
 
 				return array(
 					'headers'  => \$response->headers->getAll(),

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -133,10 +133,10 @@ trait WP_CLI_Tests_Mock_Requests_Trait {
 		}
 
 		if ( class_exists( '\WpOrg\Requests\Transport\Curl' ) ) {
-			return ( new WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
+			return ( new \WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
 		}
 
-		return ( new Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
+		return ( new \Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
 	}
 
 	public function request_multiple( \$requests, \$options ) {
@@ -149,11 +149,11 @@ trait WP_CLI_Tests_Mock_Requests_Trait {
 }
 
 if ( interface_exists( '\WpOrg\Requests\Transport' ) ) {
-	class WP_CLI_Tests_Mock_Requests_Transport implements WpOrg\Requests\Transport {
+	class WP_CLI_Tests_Mock_Requests_Transport implements \WpOrg\Requests\Transport {
 		use WP_CLI_Tests_Mock_Requests_Trait;
 	}
 } else {
-	class WP_CLI_Tests_Mock_Requests_Transport implements Requests_Transport {
+	class WP_CLI_Tests_Mock_Requests_Transport implements \Requests_Transport {
 		use WP_CLI_Tests_Mock_Requests_Trait;
 	}
 }
@@ -187,7 +187,7 @@ WP_CLI::add_wp_hook(
 							'headers' => array(),
 							'data'    => array(),
 							'options' => array_merge(
-								Requests::OPTION_DEFAULTS,
+								WpOrg\Requests\Requests::OPTION_DEFAULTS,
 								array(
 									'hooks' => new WpOrg\Requests\Hooks(),
 								)

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -132,11 +132,11 @@ trait WP_CLI_Tests_Mock_Requests_Trait {
 			}
 		}
 
-		if ( class_exists( 'Requests_Transport_cURL' ) ) {
-			return ( new Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
+		if ( class_exists( '\WpOrg\Requests\Transport\Curl' ) ) {
+			return ( new WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
 		}
 
-		return ( new WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
+		return ( new Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
 	}
 
 	public function request_multiple( \$requests, \$options ) {
@@ -148,12 +148,12 @@ trait WP_CLI_Tests_Mock_Requests_Trait {
 	}
 }
 
-if ( interface_exists( 'Requests_Transport' ) ) {
-	class WP_CLI_Tests_Mock_Requests_Transport implements Requests_Transport {
+if ( interface_exists( '\WpOrg\Requests\Transport' ) ) {
+	class WP_CLI_Tests_Mock_Requests_Transport implements WpOrg\Requests\Transport {
 		use WP_CLI_Tests_Mock_Requests_Trait;
 	}
 } else {
-	class WP_CLI_Tests_Mock_Requests_Transport implements WpOrg\Requests\Transport {
+	class WP_CLI_Tests_Mock_Requests_Transport implements Requests_Transport {
 		use WP_CLI_Tests_Mock_Requests_Trait;
 	}
 }
@@ -179,22 +179,7 @@ WP_CLI::add_wp_hook(
 					\$response = substr( \$response, 0, \$pos ) . "\r\n\r\n" . substr( \$response, \$pos + 2 );
 				}
 
-				if ( class_exists( '\Requests' ) ) {
-					\Requests::parse_multiple(
-						\$response,
-						array(
-							'url'     => \$url,
-							'headers' => array(),
-							'data'    => array(),
-							'options' => array_merge(
-								Requests::OPTION_DEFAULTS,
-								array(
-									'hooks' => new Requests_Hooks(),
-								)
-							),
-						)
-					);
-				} else {
+				if ( class_exists( '\WpOrg\Requests\Requests' ) ) {
 					WpOrg\Requests\Requests::parse_multiple(
 						\$response,
 						array(
@@ -209,8 +194,22 @@ WP_CLI::add_wp_hook(
 							),
 						)
 					);
+				} else {
+					\Requests::parse_multiple(
+						\$response,
+						array(
+							'url'     => \$url,
+							'headers' => array(),
+							'data'    => array(),
+							'options' => array_merge(
+								Requests::OPTION_DEFAULTS,
+								array(
+									'hooks' => new Requests_Hooks(),
+								)
+							),
+						)
+					);
 				}
-
 
 				return array(
 					'headers'  => \$response->headers->getAll(),

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -202,7 +202,12 @@ WP_CLI::add_wp_hook(
 							'headers' => array(),
 							'data'    => array(),
 							'options' => array(
-								'hooks' => new Requests_Hooks(),
+								'blocking'         => true,
+								'filename'         => false,
+								'follow_redirects' => true,
+								'redirected'       => 0,
+								'redirects'        => 10,
+								'hooks'            => new Requests_Hooks(),
 							),
 						)
 					);


### PR DESCRIPTION
The expected output changed because there are new table columns. Figured just changing it to CSV output makes the test more stable.

Also fixes HTTP mocking for WordPress 4.9, which uses Requests v1.

