### PR TITLE
Coverage: use old method name if available

### DIFF
--- a/utils/generate-coverage.php
+++ b/utils/generate-coverage.php
@@ -74,7 +74,11 @@ foreach ( $filtered_items as $item ) {
 
 $filter = new Filter();
 
-$filter->includeFiles( $files );
+if ( method_exists( $filter, 'include' ) ) {
+	$filter->includeFiles( $files );
+} else {
+	$filter->addFilesToWhitelist( $files );
+}
 
 $coverage = new CodeCoverage(
 	( new Selector() )->forLineCoverage( $filter ),


### PR DESCRIPTION
This fixes https://github.com/wp-cli/wp-cli-tests/issues/241#issuecomment-2841859058 and thus the coverage tests for wp-cli-bundle.

I originally thought this was not needed once we bump to PHP 7.2, but it turns out with the last PHP 7.2-compatible version of the library (v7), this is still needed.