### PR TITLE
Coverage: fix Selector usage

### DIFF
--- a/utils/generate-coverage.php
+++ b/utils/generate-coverage.php
@@ -8,6 +8,7 @@
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Selector;
+use SebastianBergmann\CodeCoverage\Driver\Xdebug;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report\PHP as PHPReport;
 
@@ -81,7 +82,8 @@ if ( method_exists( $filter, 'includeFiles' ) ) {
 }
 
 $coverage = new CodeCoverage(
-	( new Selector() )->forLineCoverage( $filter ),
+	// Selector class was only added in v9.1 of the php-code-coverage library.
+	class_exists( Selector::class ) ? ( new Selector() )->forLineCoverage( $filter ) : ( new Xdebug() ),
 	$filter
 );
 


### PR DESCRIPTION
Selector class was only added in v9.1 of the php-code-coverage library

Follow-up to #253