### PR TITLE
Dump a new autoloader when generating a Phar

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -913,11 +913,15 @@ class FeatureContext implements SnippetAcceptingContext {
 	public function build_phar( $version = 'same' ) {
 		$this->variables['PHAR_PATH'] = $this->variables['RUN_DIR'] . '/' . uniqid( 'wp-cli-build-', true ) . '.phar';
 
+		$is_bundle = false;
+
 		// Test running against a package installed as a WP-CLI dependency
 		// WP-CLI bundle installed as a project dependency
 		$make_phar_path = self::get_vendor_dir() . '/wp-cli/wp-cli-bundle/utils/make-phar.php';
 		if ( ! file_exists( $make_phar_path ) ) {
 			// Running against WP-CLI bundle proper
+			$is_bundle = true;
+
 			$make_phar_path = self::get_vendor_dir() . '/../utils/make-phar.php';
 		}
 
@@ -925,8 +929,10 @@ class FeatureContext implements SnippetAcceptingContext {
 		// so that it doesn't clash if autoloading is already happening outside of it,
 		// for example when generating code coverage.
 		// This modifies composer.json.
-		$this->composer_command( 'config autoloader-suffix "WpCliTestsPhar" --working-dir=' . dirname( self::get_vendor_dir() ) );
-		$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
+		if ( $is_bundle ) {
+			$this->composer_command( 'config autoloader-suffix "WpCliTestsPhar" --working-dir=' . dirname( self::get_vendor_dir() ) );
+			$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
+		}
 
 		$this->proc(
 			Utils\esc_cmd(
@@ -938,8 +944,10 @@ class FeatureContext implements SnippetAcceptingContext {
 		)->run_check();
 
 		// Revert the suffix change again
-		$this->composer_command( 'config autoloader-suffix "WpCliBundle" --working-dir=' . dirname( self::get_vendor_dir() ) );
-		$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
+		if ( $is_bundle ) {
+			$this->composer_command( 'config autoloader-suffix "WpCliBundle" --working-dir=' . dirname( self::get_vendor_dir() ) );
+			$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
+		}
 	}
 
 	public function download_phar( $version = 'same' ) {

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -202,7 +202,7 @@ class FeatureContext implements SnippetAcceptingContext {
 	 * @AfterSuite
 	 */
 	public static function merge_coverage_reports() {
-		if ( self::running_with_code_coverage() ) {
+		if ( ! self::running_with_code_coverage() ) {
 			return;
 		}
 

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -921,6 +921,13 @@ class FeatureContext implements SnippetAcceptingContext {
 			$make_phar_path = self::get_vendor_dir() . '/../utils/make-phar.php';
 		}
 
+		// Temporarily modify the Composer autoloader used within the Phar
+		// so that it doesn't clash if autoloading is already happening outside of it,
+		// for example when generating code coverage.
+		// This modifies composer.json.
+		$this->composer_command( 'config autoloader-suffix "WpCliTestsPhar" --working-dir=' . dirname( self::get_vendor_dir() ) );
+		$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
+
 		$this->proc(
 			Utils\esc_cmd(
 				'php -dphar.readonly=0 %1$s %2$s --version=%3$s && chmod +x %2$s',
@@ -929,6 +936,10 @@ class FeatureContext implements SnippetAcceptingContext {
 				$version
 			)
 		)->run_check();
+
+		// Revert the suffix change again
+		$this->composer_command( 'config autoloader-suffix "WpCliBundle" --working-dir=' . dirname( self::get_vendor_dir() ) );
+		$this->composer_command( 'dump-autoload --working-dir=' . dirname( self::get_vendor_dir() ) );
 	}
 
 	public function download_phar( $version = 'same' ) {


### PR DESCRIPTION
This is related to the remaining failing Behat tests when code coverage is running.

Basically what happens in the wp-cli-bundle repo is that we include the autoloader once in `generate-coverage.php`, and then in the generated Phar the same autoloader is included again. That causes a fatal error because the same `ComposerAutoloaderInit...` class is declared twice.

This PR addresses this by temporarily changing the autoloader class suffix for that generated Phar. Requires otherwise using a hardcoded suffix (instead of the default `content-hash`). See https://github.com/wp-cli/wp-cli-bundle/pull/764 for that.

Requires the PHP 7.2 bump, see https://github.com/wp-cli/wp-cli-bundle/pull/760

See [Slack discussion](https://wordpress.slack.com/archives/C02RP4T41/p1746635308451319) for additional context