### PR TITLE
PHP 8.5: Use `shell_exec` instead of backticks

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -769,7 +769,7 @@ class FeatureContext implements SnippetAcceptingContext {
 	 */
 	private static function terminate_proc( $master_pid ): void {
 
-		$output = `ps -o ppid,pid,command | grep $master_pid`;
+		$output = shell_exec( "ps -o ppid,pid,command | grep $master_pid" );
 
 		foreach ( explode( PHP_EOL, $output ) as $line ) {
 			if ( preg_match( '/^\s*(\d+)\s+(\d+)/', $line, $matches ) ) {


### PR DESCRIPTION
Using backticks is deprecated in PHP 8.5, see https://github.com/php/php-src/commit/3d9d68e1cacf8d185de6281bfec058b22e3094f8

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
