### PR TITLE
Conditionally pass Behat `--xdebug` flag

### DIFF
--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -44,5 +44,10 @@ export WP_CLI_TESTS_ROOT
 # Generate the tags to apply environment-specific filters.
 BEHAT_TAGS=$(php "$WP_CLI_TESTS_ROOT"/utils/behat-tags.php)
 
+BEHAT_EXTRA_ARGS=()
+if [[ "${WP_CLI_TEST_COVERAGE}" == "true" ]] && vendor/bin/behat --help 2>/dev/null | grep -q 'xdebug'; then
+	BEHAT_EXTRA_ARGS+=('--xdebug')
+fi
+
 # Run the functional tests.
-vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "$@"
+vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "${BEHAT_EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
This logic was previously in the reusable workflow in the `wp-cli/.github` repo, but in https://github.com/wp-cli/.github/pull/157 I removed it (mostly by accident).

I forgot that `wp-cli/wp-cli-bundle` runs tests with Behat 3.15 which doesn't know the `--xdebug` (which is why we had this check in the first place). It's easier to check for `WP_CLI_TEST_COVERAGE` in this script itself. This makes local testing easier as well, so you only need to run `WP_CLI_TEST_COVERAGE=true` composer behat` and don't need to remember whether you need to pass `-- --xdebug` as well or not.