### PR TITLE
Composer: adjust version ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "dev-develop",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^1.12.26",
-        "phpstan/phpstan-deprecation-rules": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpstan/phpstan-strict-rules": "^1.6",
-        "swissspidy/phpstan-no-private": "^0.2.1",
+        "phpstan/phpstan": "^1.12.26 || ^2.0",
+        "phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",
+        "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+        "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+        "swissspidy/phpstan-no-private": "^0.2.1 || ^1.0",
         "szepeviktor/phpstan-wordpress": "^v1.3.5",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",
         "wp-cli/wp-cli": "^2.12",
         "wp-coding-standards/wpcs": "^3",
-        "yoast/phpunit-polyfills": "^4.0.0"
+        "yoast/phpunit-polyfills": "^1.0 || ^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
This should make it easier for someone to use `wp-cli-tests` together with e.g. PHPStan 2.0 if they want to