### PR TITLE
Pin `behat/gherkin` to fix PHP 8.5 tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": ">=7.2.24",
         "behat/behat": "^v3.15.0",
+        "behat/gherkin": "<v4.15.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",


### PR DESCRIPTION
See https://github.com/Behat/Behat/pull/1636 for context.

`behat/gherkin` had a breaking change that `behat/behat` had to accommodate for. Since we're stuck at Behat 3.15, but were using a newer version of `behat/gherkin`, that caused an incompatibility. This showed in PHP 8.5 tests once `behat/gherkin` [v4.15.0](https://github.com/Behat/Gherkin/releases/tag/v4.15.0) was released which introduced 8.5 compatibility.

tl;dr: this PR here will fix PHP 8.5 tests for all our commands once they update the wp-cli-tests dependency.