### PR TITLE
Fix PHPCompatibility & WPCS requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "wp-cli/core-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",
         "wp-cli/wp-cli": "^2.12",
-        "wp-coding-standards/wpcs": "^3",
+        "wp-coding-standards/wpcs": "dev-develop",
         "yoast/phpunit-polyfills": "^1.0 || ^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
PHPCompatibility v10.0.0-alpha was just released, which now requires `squizlabs/php_codesniffer` v4.

Because we were already using the develop branch, all our CI jobs are currently failing with dependency mismatches.

