### PR TITLE
Support nested variables in `INVOKE_WP_CLI_WITH_PHP_ARGS`

### DIFF
--- a/features/steps.feature
+++ b/features/steps.feature
@@ -68,6 +68,12 @@ Feature: Make sure "Given", "When", "Then" steps work as expected
     Then STDOUT should match /\d\.\d/
     And STDERR should be empty
 
+  Scenario: Nested special variables
+    Given an empty directory
+    When I run `echo {INVOKE_WP_CLI_WITH_PHP_ARGS--dopen_basedir={RUN_DIR}} cli info`
+    Then STDOUT should match /^WP_CLI_PHP_ARGS=-dopen_basedir=.* ?wp cli info/
+    And STDERR should be empty
+
   @require-mysql-or-mariadb
   Scenario: SQL related variables
     When I run `echo {MYSQL_BINARY}`

--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -980,7 +980,7 @@ class FeatureContext implements Context {
 		}
 
 		$str = preg_replace_callback(
-			'/{INVOKE_WP_CLI_WITH_PHP_ARGS-([^}]*)}/',
+			'/{INVOKE_WP_CLI_WITH_PHP_ARGS-(.*)}/',
 			static function ( $matches ) use ( $phar_path, $shell_path ) {
 				return $phar_path ? "php {$matches[1]} {$phar_path}" : ( 'WP_CLI_PHP_ARGS=' . escapeshellarg( $matches[1] ) . ' ' . $shell_path );
 			},


### PR DESCRIPTION
Noticed in https://github.com/wp-cli/wp-cli/pull/6192 that this currently doesn't work, but seems reasonable to change this.