### PR TITLE
Fix typo in `WPCliRuncommandDynamicReturnTypeExtension`

### DIFF
--- a/src/PHPStan/WPCliRuncommandDynamicReturnTypeExtension.php
+++ b/src/PHPStan/WPCliRuncommandDynamicReturnTypeExtension.php
@@ -84,7 +84,7 @@ class WPCliRuncommandDynamicReturnTypeExtension implements DynamicStaticMethodRe
 
 								if ( $isExactlyJsonString ) {
 									$parseOption = $valueConstantStrings[0];
-								} elseif ( $$currentOptionValueType->isFalse()->yes() ) {
+								} elseif ( $currentOptionValueType->isFalse()->yes() ) {
 									$parseOption = new ConstantBooleanType( false );
 								} else {
 									// Not a single, clear constant we handle for a "known" path


### PR DESCRIPTION
Prevents "Object of class PHPStan\Type\Constant\ConstantBooleanType could not be converted to string" errors when running PHPStan against code bases triggering this code path.