### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -75,7 +75,7 @@ To make use of the WP-CLI testing framework, you need to complete the following 
     </ruleset>
     ```
 
-    All other [PHPCS configuration options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
+    All other [PHPCS configuration options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
 6. Update your composer dependencies and regenerate your autoloader and binary folders:
     ```bash
     composer update

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To make use of the WP-CLI testing framework, you need to complete the following 
     </ruleset>
     ```
 
-    All other [PHPCS configuration options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
+    All other [PHPCS configuration options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
 6. Update your composer dependencies and regenerate your autoloader and binary folders:
     ```bash
     composer update

--- a/WP_CLI_CS/ruleset.xml
+++ b/WP_CLI_CS/ruleset.xml
@@ -7,8 +7,8 @@
 	To include this ruleset in a WP-CLI project, use `rule ref="WP_CLI_CS"` in brackets.
 	See the instructions in the README/USING for an example.
 
-	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
-	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage
+	For help understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	-->
 
 	<!--
@@ -18,7 +18,7 @@
 	-->
 
 	<!-- Ignoring select files/folders for all projects.
-		 https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		 https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>*/.git/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,8 +5,8 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	For help understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage
 	#############################################################################
 	-->
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932