### PR TITLE
Normalize temp dir in `Given a directory` step

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1211,6 +1211,7 @@ class FeatureContext implements Context {
 		if ( ! isset( $this->variables['RUN_DIR'] ) ) {
 			$temp_run_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid( 'wp-cli-test-run-' . self::$temp_dir_infix . '-', true );
 			mkdir( $temp_run_dir );
+			$temp_run_dir               = realpath( $temp_run_dir ) ?: $temp_run_dir;
 			self::$run_dir              = $temp_run_dir;
 			$this->variables['RUN_DIR'] = self::$run_dir;
 		}

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -53,8 +53,12 @@ trait GivenStepDefinitions {
 		// Mac OS X can prefix the `/var` folder to turn it into `/private/var`.
 		$dir = preg_replace( '|^/private/var/|', '/var/', $dir );
 
-		$temp_dir = Path::normalize( sys_get_temp_dir() );
+		$temp_dir = realpath( sys_get_temp_dir() );
+		$temp_dir = $temp_dir ? Path::normalize( $temp_dir ) : Path::normalize( sys_get_temp_dir() );
 		$dir      = Path::normalize( $dir );
+
+		// Also normalize temp dir for Mac OS X.
+		$temp_dir = preg_replace( '|^/private/var/|', '/var/', $temp_dir );
 
 		// Also check for temp dir prefixed with `/private` for Mac OS X.
 		if ( 0 !== strpos( $dir, $temp_dir ) && 0 !== strpos( $dir, "/private{$temp_dir}" ) ) {


### PR DESCRIPTION
This fixes some failing Windows tests in language-command and potentially others using `Given a(n) ... directory`.