### PR TITLE
HTTP mocking: support `filename` option

### DIFF
--- a/features/http-mocking.feature
+++ b/features/http-mocking.feature
@@ -119,3 +119,20 @@ Feature: HTTP request mocking
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url |
       | 999.9.9 | major       | https://downloads.wordpress.org/release/wordpress-999.9.9.zip |
+
+  Scenario: Mock HTTP request with filename option writes to disk
+    Given an empty directory
+    And that HTTP requests to https://example.com/mocked-file.txt will respond with:
+      """
+      HTTP/1.1 200 OK
+      Content-Type: text/plain
+
+      Mocked file contents on disk!
+      """
+
+    When I try `wp eval 'WP_CLI\Utils\http_request("GET", "https://example.com/mocked-file.txt", null, [], ["filename" => "downloaded.txt"]);' --skip-wordpress`
+    Then the return code should be 0
+    And the downloaded.txt file should contain:
+      """
+      Mocked file contents on disk!
+      """

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -228,6 +228,14 @@ trait WP_CLI_Tests_Mock_Requests_Trait {
 				if ( false !== \$pos ) {
 					\$response = substr( \$response, 0, \$pos ) . "\\r\\n\\r\\n" . substr( \$response, \$pos + 2 );
 				}
+				if ( ! empty( \$options['filename'] ) ) {
+					\$body = '';
+					\$body_pos = strpos( \$response, "\\r\\n\\r\\n" );
+					if ( false !== \$body_pos ) {
+						\$body = substr( \$response, \$body_pos + 4 );
+					}
+					file_put_contents( \$options['filename'], \$body );
+				}
 				return \$response;
 			}
 		}
@@ -311,6 +319,10 @@ WP_CLI::add_wp_hook(
 							),
 						)
 					);
+				}
+
+				if ( ! empty( \$parsed_args['filename'] ) ) {
+					file_put_contents( \$parsed_args['filename'], \$response->body );
 				}
 
 				return array(


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
