### PR TITLE
Skip server certificate verification for MariaDB test connections

### DIFF
--- a/src/Context/FeatureContext.php
+++ b/src/Context/FeatureContext.php
@@ -1341,7 +1341,7 @@ class FeatureContext implements Context {
 		}
 
 		$dbname   = self::$db_settings['dbname'];
-		$ssl_flag = 'mariadb' === self::$db_type ? ' --ssl-verify-server-cert' : '';
+		$ssl_flag = 'mariadb' === self::$db_type ? ' --skip-ssl-verify-server-cert' : '';
 		self::run_sql( self::$mysql_binary . ' --no-defaults' . $ssl_flag, [ 'execute' => "CREATE DATABASE IF NOT EXISTS $dbname" ] );
 	}
 
@@ -1353,7 +1353,7 @@ class FeatureContext implements Context {
 			return;
 		}
 
-		$ssl_flag   = 'mariadb' === self::$db_type ? ' --ssl-verify-server-cert' : '';
+		$ssl_flag   = 'mariadb' === self::$db_type ? ' --skip-ssl-verify-server-cert' : '';
 		$sql_result = self::run_sql(
 			self::$mysql_binary . ' --no-defaults' . $ssl_flag,
 			[
@@ -1382,7 +1382,7 @@ class FeatureContext implements Context {
 			return;
 		}
 		$dbname   = self::$db_settings['dbname'];
-		$ssl_flag = 'mariadb' === self::$db_type ? ' --ssl-verify-server-cert' : '';
+		$ssl_flag = 'mariadb' === self::$db_type ? ' --skip-ssl-verify-server-cert' : '';
 		self::run_sql( self::$mysql_binary . ' --no-defaults' . $ssl_flag, [ 'execute' => "DROP DATABASE IF EXISTS $dbname" ] );
 	}
 
@@ -1756,7 +1756,7 @@ class FeatureContext implements Context {
 					copy( "{$install_cache_path}.sqlite", "$sqlite_dest_dir/.ht.sqlite.php" );
 				}
 			} else {
-				$ssl_flag = 'mariadb' === self::$db_type ? ' --ssl-verify-server-cert' : '';
+				$ssl_flag = 'mariadb' === self::$db_type ? ' --skip-ssl-verify-server-cert' : '';
 				self::run_sql( self::$mysql_binary . ' --no-defaults' . $ssl_flag, [ 'execute' => "source {$install_cache_path}.sql" ], true /*add_database*/ );
 			}
 		} else {
@@ -1773,7 +1773,7 @@ class FeatureContext implements Context {
 				$mysqldump_binary          = Utils\force_env_on_nix_systems( $mysqldump_binary );
 				$help_output               = shell_exec( "{$mysqldump_binary} --help" );
 				$support_column_statistics = ( null !== $help_output && false !== strpos( $help_output, 'column-statistics' ) );
-				$ssl_flag                  = 'mariadb' === self::$db_type ? ' --ssl-verify-server-cert' : '';
+				$ssl_flag                  = 'mariadb' === self::$db_type ? ' --skip-ssl-verify-server-cert' : '';
 				$command                   = "{$mysqldump_binary} --no-defaults{$ssl_flag} --no-tablespaces";
 				if ( $support_column_statistics ) {
 					$command .= ' --skip-column-statistics';


### PR DESCRIPTION
## Summary

Follow-up to #297. That change passed `--ssl-verify-server-cert` to the MariaDB
client calls in the test harness to silence the passwordless-login warning. That
flag enables certificate verification though, which forces TLS server
certificate checks that fail against self-signed or untrusted certificates, and
on clients older than 11.4 where verification was off by default.

## Approach

Switch the five call sites to `--skip-ssl-verify-server-cert`, which explicitly
disables verification for the local test database. It silences the same warning
without turning verification on, so it also works when the client would
otherwise reject the self-signed certificate. The database type auto-detection
added in #297 is kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MariaDB database operations by using the appropriate SSL certificate verification setting.
  * Updated database creation, connection testing, deletion, and import/export workflows for more reliable MariaDB support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->