### PR TITLE
Fix `WPCliRuncommandDynamicReturnTypeExtension` when passing invalid options

### DIFF
--- a/src/PHPStan/WPCliRuncommandDynamicReturnTypeExtension.php
+++ b/src/PHPStan/WPCliRuncommandDynamicReturnTypeExtension.php
@@ -39,7 +39,7 @@ class WPCliRuncommandDynamicReturnTypeExtension implements DynamicStaticMethodRe
 	): Type {
 		$args = $methodCall->getArgs();
 
-		$returnOption      = new ConstantBooleanType( true );
+		$returnOption      = new ConstantBooleanType( false );
 		$parseOption       = new ConstantBooleanType( false );
 		$exitOnErrorOption = new ConstantBooleanType( true );
 

--- a/tests/data/runcommand.php
+++ b/tests/data/runcommand.php
@@ -65,3 +65,14 @@ $value = WP_CLI::runcommand(
 	]
 );
 assertType( 'string', $value );
+
+$value = WP_CLI::runcommand( 'plugin list' );
+assertType( 'null', $value );
+
+$value = WP_CLI::runcommand(
+	'plugin list',
+	[
+		'exit_error' => false,
+	]
+);
+assertType( 'null', $value );


### PR DESCRIPTION
Any call like `WP_CLI::runcommand('plugin list')` (omitting options or omitting 'return') was wrongly typed by PHPStan as `string` instead of `null`.

As noticed in https://github.com/wp-cli/wp-cli/pull/6345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for `WP_CLI::runcommand()` when no `return` option is specified.
  * Calls that execute commands without returning output are now correctly inferred as returning `null`.
  * Added coverage for default behavior and calls with `exit_error` disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->