### PR TITLE
Add PHPCS linting for PHP blocks in feature files

### DIFF
--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -78,6 +78,8 @@ To make use of the WP-CLI testing framework, you need to complete the following 
     ```
 
     All other [PHPCS configuration options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset) are, of course, available.
+    The PHP snippets embedded in your feature files are checked along with the rest of the package. See [Checking the code style of the PHP blocks in feature files](#checking-the-code-style-of-the-php-blocks-in-feature-files) below.
+
 6. Optionally add a `phpstan-feature-files.neon.dist` file to the package root to also run PHPStan over the PHP snippets embedded in your feature files. See [Analysing the PHP blocks in feature files](#analysing-the-php-blocks-in-feature-files) below.
 
 7. Update your composer dependencies and regenerate your autoloader and binary folders:
@@ -164,6 +166,56 @@ Two kinds of blocks are left out of the analysis, and are listed at the end of t
 
 Blocks that declare the same class or function as another block are analysed separately from each
 other, so that PHPStan does not resolve a name to the wrong block's declaration.
+
+### Checking the code style of the PHP blocks in feature files
+
+`composer phpcs` also checks the PHP snippets that feature files embed in docstrings, and
+`composer phpcbf` fixes them in place. No configuration is needed, and like the analysis above the
+blocks are padded so that findings are reported against the feature file itself:
+
+```text
+FILE: features/command.feature
+----------------------------------------------------------------------
+FOUND 1 ERROR AFFECTING 1 LINE
+----------------------------------------------------------------------
+ 438 | ERROR | [x] Expected 1 space after IF keyword; 0 found
+----------------------------------------------------------------------
+```
+
+Only a docstring belonging to a step that creates a `.php` file is checked:
+
+```gherkin
+Given a wp-content/mu-plugins/test-harness.php file:
+  """
+  <?php
+  WP_CLI::add_command( 'test-harness', 'Test_Harness' );
+  """
+```
+
+Unlike the analysis above, a docstring that merely opens with `<?php` does not count. Those are
+routinely an expectation about the contents of a file rather than a file, and reformatting one would
+make it stop matching what it is checked against.
+
+The defaults leave out the sniffs that look at a block as if it were a file of its own, along with
+those that ask of a fixture what is only worth asking of production code. They live in
+`phpcs/feature-files.sh` and are shared by the check and the fixer, so that the two cannot disagree
+over which sniff applies. A package replaces them wholesale by adding a `phpcs-feature-files.xml`
+(or `phpcs-feature-files.xml.dist`) ruleset to its root:
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-PROJECT-NAME-feature-files">
+    <arg name="warning-severity" value="0"/>
+
+    <rule ref="WP_CLI_CS">
+        <exclude name="Generic.Files.InlineHTML"/>
+        <exclude name="Squiz.Commenting.FileComment"/>
+    </rule>
+</ruleset>
+```
+
+The blocks are left alone when a run is narrowed down to a path, as in `composer phpcs -- src/`,
+since such an argument is about the files of the package itself.
 
 ### Controlling what to test
 

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcbf --standard=WP_CLI_CS \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax \
 			"$TEMP_DIR" >/dev/null 2>&1
 
 		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -1,7 +1,30 @@
 #!/bin/sh
 
-# Run the code style check only if a configuration file exists.
+EXIT_CODE=0
+
+# 1. Run standard PHPCBF if configuration file exists.
 if [ -f ".phpcs.xml" ] || [ -f "phpcs.xml" ] || [ -f ".phpcs.xml.dist" ] || [ -f "phpcs.xml.dist" ]
 then
-	vendor/bin/phpcbf "$@"
+	vendor/bin/phpcbf "$@" || EXIT_CODE=$?
 fi
+
+# 2. Run PHPCBF over extracted PHP blocks in .feature files and sync back fixes.
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -d "features" ] && [ -f "$DIR/utils/extract-feature-php.php" ]
+then
+	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcbf')
+	trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+	php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null 2>&1
+
+	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+	then
+		vendor/bin/phpcbf --standard=WP_CLI_CS \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Generic.WhiteSpace.DisallowSpaceIndent,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			"$TEMP_DIR" >/dev/null 2>&1
+
+		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1
+	fi
+fi
+
+exit $EXIT_CODE

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcbf --standard=WP_CLI_CS \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
 			"$TEMP_DIR" >/dev/null 2>&1
 
 		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcbf --standard=WP_CLI_CS \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals \
 			"$TEMP_DIR" >/dev/null 2>&1
 
 		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcbf --standard=WP_CLI_CS \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Generic.WhiteSpace.DisallowSpaceIndent,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
 			"$TEMP_DIR" >/dev/null 2>&1
 
 		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -15,15 +15,19 @@ then
 	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcbf')
 	trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 
-	php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null 2>&1
-
-	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+	# Fixes are only synced back when the extraction they are based on succeeded.
+	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null
 	then
-		vendor/bin/phpcbf --standard=WP_CLI_CS \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
-			"$TEMP_DIR" >/dev/null 2>&1
+		if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+		then
+			vendor/bin/phpcbf --standard=WP_CLI_CS \
+				--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
+				"$TEMP_DIR" >/dev/null || EXIT_CODE=$?
 
-		php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null 2>&1
+			php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null || EXIT_CODE=$?
+		fi
+	else
+		EXIT_CODE=1
 	fi
 fi
 

--- a/bin/run-phpcbf-cleanup
+++ b/bin/run-phpcbf-cleanup
@@ -8,20 +8,68 @@ then
 	vendor/bin/phpcbf "$@" || EXIT_CODE=$?
 fi
 
-# 2. Run PHPCBF over extracted PHP blocks in .feature files and sync back fixes.
-DIR="$(cd "$(dirname "$0")/.." && pwd)"
-if [ -d "features" ] && [ -f "$DIR/utils/extract-feature-php.php" ]
+# 2. Run PHPCBF over the PHP blocks in .feature files and sync back fixes.
+# Composer installs this script as a symlink in the vendor binary directory, so
+# it has to be resolved before the root of this package can be derived from it.
+SOURCE="$0"
+while [ -h "$SOURCE" ]
+do
+	SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+	SOURCE="$(readlink "$SOURCE")"
+	# A relative symlink is resolved against the directory holding the symlink.
+	case "$SOURCE" in
+		/*) ;;
+		*) SOURCE="$SOURCE_DIR/$SOURCE" ;;
+	esac
+done
+DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+
+# A ruleset of the same purpose in the package root replaces the defaults
+# wholesale. Both scripts read the defaults from the same file, so that the
+# check and the fixer cannot disagree over which sniff applies to a block.
+FEATURE_STANDARD=""
+for CANDIDATE in "phpcs-feature-files.xml" "phpcs-feature-files.xml.dist"
+do
+	if [ -f "$CANDIDATE" ]
+	then
+		FEATURE_STANDARD="$(pwd)/$CANDIDATE"
+		break
+	fi
+done
+
+FEATURE_ARGS=""
+if [ -z "$FEATURE_STANDARD" ] && [ -f "$DIR/phpcs/feature-files.sh" ]
+then
+	. "$DIR/phpcs/feature-files.sh"
+	FEATURE_STANDARD="$WP_CLI_TESTS_FEATURE_STANDARD"
+	# Holds no path, so leaving it unquoted below splits it into arguments.
+	FEATURE_ARGS="$WP_CLI_TESTS_FEATURE_ARGS"
+fi
+
+# An argument naming what to fix applies to the files of the package itself, so
+# the blocks are left alone once a run has been narrowed down to a path.
+FIX_BLOCKS=1
+for ARG in "$@"
+do
+	case "$ARG" in
+		-*) ;;
+		*) FIX_BLOCKS=0 ;;
+	esac
+done
+
+if [ "$FIX_BLOCKS" -eq 1 ] && [ -d "features" ] && [ -n "$FEATURE_STANDARD" ] \
+	&& [ -f "$DIR/utils/extract-feature-php.php" ]
 then
 	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcbf')
 	trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 
 	# Fixes are only synced back when the extraction they are based on succeeded.
-	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null
+	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR"
 	then
-		if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+		if [ -n "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 		then
-			vendor/bin/phpcbf --standard=WP_CLI_CS \
-				--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
+			# shellcheck disable=SC2086 # Intentional word splitting.
+			vendor/bin/phpcbf --standard="$FEATURE_STANDARD" $FEATURE_ARGS \
 				"$TEMP_DIR" >/dev/null || EXIT_CODE=$?
 
 			php "$DIR/utils/extract-feature-php.php" update features "$TEMP_DIR" >/dev/null || EXIT_CODE=$?

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -1,7 +1,28 @@
 #!/bin/sh
 
-# Run the code style check only if a configuration file exists.
+EXIT_CODE=0
+
+# 1. Run standard PHP code style check if a configuration file exists.
 if [ -f ".phpcs.xml" ] || [ -f "phpcs.xml" ] || [ -f ".phpcs.xml.dist" ] || [ -f "phpcs.xml.dist" ]
 then
-	vendor/bin/phpcs "$@"
+	vendor/bin/phpcs "$@" || EXIT_CODE=$?
 fi
+
+# 2. Run PHPCS over extracted PHP blocks in .feature files if features/ directory exists.
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -d "features" ] && [ -f "$DIR/utils/extract-feature-php.php" ]
+then
+	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcs')
+	trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+	php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null 2>&1
+
+	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+	then
+		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Generic.WhiteSpace.DisallowSpaceIndent,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
+	fi
+fi
+
+exit $EXIT_CODE

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax \
 			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
 	fi
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Generic.WhiteSpace.DisallowSpaceIndent,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
 			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
 	fi
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals \
 			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
 	fi
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -20,7 +20,7 @@ then
 	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 	then
 		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax \
+			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
 			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
 	fi
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -8,31 +8,80 @@ then
 	vendor/bin/phpcs "$@" || EXIT_CODE=$?
 fi
 
-# 2. Run PHPCS over extracted PHP blocks in .feature files if features/ directory exists.
-DIR="$(cd "$(dirname "$0")/.." && pwd)"
-if [ -d "features" ] && [ -f "$DIR/utils/extract-feature-php.php" ]
+# 2. Run PHPCS over the PHP blocks in .feature files.
+# Composer installs this script as a symlink in the vendor binary directory, so
+# it has to be resolved before the root of this package can be derived from it.
+SOURCE="$0"
+while [ -h "$SOURCE" ]
+do
+	SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+	SOURCE="$(readlink "$SOURCE")"
+	# A relative symlink is resolved against the directory holding the symlink.
+	case "$SOURCE" in
+		/*) ;;
+		*) SOURCE="$SOURCE_DIR/$SOURCE" ;;
+	esac
+done
+DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+
+# A ruleset of the same purpose in the package root replaces the defaults
+# wholesale. Both scripts read the defaults from the same file, so that the
+# check and the fixer cannot disagree over which sniff applies to a block.
+FEATURE_STANDARD=""
+for CANDIDATE in "phpcs-feature-files.xml" "phpcs-feature-files.xml.dist"
+do
+	if [ -f "$CANDIDATE" ]
+	then
+		FEATURE_STANDARD="$(pwd)/$CANDIDATE"
+		break
+	fi
+done
+
+FEATURE_ARGS=""
+if [ -z "$FEATURE_STANDARD" ] && [ -f "$DIR/phpcs/feature-files.sh" ]
+then
+	. "$DIR/phpcs/feature-files.sh"
+	FEATURE_STANDARD="$WP_CLI_TESTS_FEATURE_STANDARD"
+	# Holds no path, so leaving it unquoted below splits it into arguments.
+	FEATURE_ARGS="$WP_CLI_TESTS_FEATURE_ARGS"
+fi
+
+# An argument naming what to check applies to the files of the package itself,
+# so the blocks are left alone once a run has been narrowed down to a path.
+CHECK_BLOCKS=1
+for ARG in "$@"
+do
+	case "$ARG" in
+		-*) ;;
+		*) CHECK_BLOCKS=0 ;;
+	esac
+done
+
+if [ "$CHECK_BLOCKS" -eq 1 ] && [ -d "features" ] && [ -n "$FEATURE_STANDARD" ] \
+	&& [ -f "$DIR/utils/extract-feature-php.php" ]
 then
 	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcs')
 	PHPCS_OUTPUT=$(mktemp 2>/dev/null || mktemp -t 'feature_phpcs_output')
 	trap 'rm -rf "$TEMP_DIR" "$PHPCS_OUTPUT"' EXIT HUP INT TERM
 
-	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null
+	# Results are only reported when the extraction they are based on succeeded.
+	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR"
 	then
-		if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+		if [ -n "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
 		then
 			# The report is written to a file so that the status of PHPCS itself
-			# is preserved instead of the status of the commands rewriting it.
-			vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-				--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
-				"$TEMP_DIR" >"$PHPCS_OUTPUT" 2>&1 || EXIT_CODE=$?
+			# is preserved instead of the status of the command rewriting it.
+			# `--basepath` reduces the reported paths to the part that is worth
+			# showing, which also keeps PHPCS from truncating them from the left
+			# once they grow past the width of the report.
+			# shellcheck disable=SC2086 # Intentional word splitting.
+			vendor/bin/phpcs --standard="$FEATURE_STANDARD" $FEATURE_ARGS \
+				--basepath="$TEMP_DIR" "$TEMP_DIR" >"$PHPCS_OUTPUT" 2>&1 || EXIT_CODE=$?
 
-			# The temporary directory is reported through its resolved path.
-			TEMP_DIR_REAL=$(cd "$TEMP_DIR" && pwd -P)
-
+			# Findings are reported against the feature files they came from.
 			sed -E \
+				-e 's|^FILE: |FILE: features/|' \
 				-e 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' \
-				-e "s|$TEMP_DIR_REAL/|features/|g" \
-				-e "s|$TEMP_DIR/|features/|g" \
 				"$PHPCS_OUTPUT"
 		fi
 	else

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -13,15 +13,30 @@ DIR="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -d "features" ] && [ -f "$DIR/utils/extract-feature-php.php" ]
 then
 	TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'feature_phpcs')
-	trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+	PHPCS_OUTPUT=$(mktemp 2>/dev/null || mktemp -t 'feature_phpcs_output')
+	trap 'rm -rf "$TEMP_DIR" "$PHPCS_OUTPUT"' EXIT HUP INT TERM
 
-	php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null 2>&1
-
-	if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+	if php "$DIR/utils/extract-feature-php.php" extract features "$TEMP_DIR" >/dev/null
 	then
-		vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
-			--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
-			"$TEMP_DIR" 2>&1 | sed -E 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' | sed -E "s|FILE: .*/([^/]+\.feature)|FILE: features/\1|g" || EXIT_CODE=$?
+		if [ -d "$TEMP_DIR" ] && [ "$(ls -A "$TEMP_DIR" 2>/dev/null)" ]
+		then
+			# The report is written to a file so that the status of PHPCS itself
+			# is preserved instead of the status of the commands rewriting it.
+			vendor/bin/phpcs --standard=WP_CLI_CS --warning-severity=0 \
+				--exclude=Generic.Files.InlineHTML,Generic.Files.LineEndings,WordPress.Files.FileName,Squiz.Commenting.FileComment,Universal.WhiteSpace.PrecisionAlignment,PSR2.Files.EndFileNewline,PSR2.Methods.FunctionClosingBrace,Generic.PHP.CharacterBeforePHPOpenTag,Generic.PHP.RequireStrictTypes,Squiz.WhiteSpace.SuperfluousWhitespace,WordPress.NamingConventions.PrefixAllGlobals,Universal.Files.SeparateFunctionsFromOO,Generic.Files.OneObjectStructurePerFile,WordPress.WP.GlobalVariablesOverride,Universal.Namespaces.OneDeclarationPerFile,Universal.Namespaces.DisallowCurlyBraceSyntax,WordPress.PHP.YodaConditions,Universal.Namespaces.DisallowDeclarationWithoutName,PSR12.Files.FileHeader,Generic.CodeAnalysis.EmptyStatement \
+				"$TEMP_DIR" >"$PHPCS_OUTPUT" 2>&1 || EXIT_CODE=$?
+
+			# The temporary directory is reported through its resolved path.
+			TEMP_DIR_REAL=$(cd "$TEMP_DIR" && pwd -P)
+
+			sed -E \
+				-e 's/\.feature_L[0-9]+_E[0-9]+_(HASPHP|NOPHP)\.php/.feature/g' \
+				-e "s|$TEMP_DIR_REAL/|features/|g" \
+				-e "s|$TEMP_DIR/|features/|g" \
+				"$PHPCS_OUTPUT"
+		fi
+	else
+		EXIT_CODE=1
 	fi
 fi
 

--- a/features/behat-steps.feature
+++ b/features/behat-steps.feature
@@ -549,7 +549,7 @@ Feature: Test that WP-CLI Behat steps work as expected
     And a send-email.php file:
       """
       <?php
-      wp_mail('test@example.com', 'Test', 'Body');
+      wp_mail( 'test@example.com', 'Test', 'Body' );
       """
     When I run `wp eval-file send-email.php`
     Then an email should be sent

--- a/features/testing.feature
+++ b/features/testing.feature
@@ -18,7 +18,7 @@ Feature: Test that WP-CLI loads.
     And a test_cron.php file:
       """
       <?php
-      $cron_disabled = defined( "DISABLE_WP_CRON" ) ? DISABLE_WP_CRON : false;
+      $cron_disabled = defined( 'DISABLE_WP_CRON' ) ? DISABLE_WP_CRON : false;
       echo 'DISABLE_WP_CRON is: ' . ( $cron_disabled ? 'true' : 'false' );
       """
 

--- a/phpcs/feature-files.sh
+++ b/phpcs/feature-files.sh
@@ -1,0 +1,57 @@
+# Defaults for the code style check of the PHP blocks embedded in Behat feature
+# files, shared by `run-phpcs-tests` and `run-phpcbf-cleanup`.
+#
+# Keeping the list in one place is what makes the check and the fixer agree: a
+# sniff excluded for one but not the other would have the fixer rewrite feature
+# files over something the check never reports, or have the check report
+# something the fixer refuses to touch.
+#
+# The exclusions are passed on the command line rather than declared in a
+# ruleset because a ruleset aborts the whole run over a sniff that the installed
+# PHP_CodeSniffer does not know, while `--exclude` passes over it. The list
+# spans several major versions of PHP_CodeSniffer and of the standards it
+# builds on, and not every entry exists in all of them.
+#
+# A package replaces these defaults wholesale by adding a
+# `phpcs-feature-files.xml` (or `phpcs-feature-files.xml.dist`) ruleset to its
+# root, which is then used as the standard instead.
+
+WP_CLI_TESTS_FEATURE_STANDARD="WP_CLI_CS"
+
+# Warnings are advisory, and the fixer must not rewrite a feature file over
+# something the check does not report.
+WP_CLI_TESTS_FEATURE_ARGS="--warning-severity=0"
+
+# A block is not a file. It is padded with one empty line per preceding line of
+# the feature file so that reported line numbers match it, and one that does not
+# bring its own opening tag is given one. Neither is part of the snippet, and
+# the shared docstring indentation is taken off before the check and put back
+# afterwards, so none of the sniffs looking at a file as a whole apply.
+WP_CLI_TESTS_FEATURE_EXCLUDES="Generic.Files.InlineHTML"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Generic.PHP.CharacterBeforePHPOpenTag"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Generic.Files.LineEndings"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,PSR2.Files.EndFileNewline"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,PSR12.Files.FileHeader"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Squiz.Commenting.FileComment"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Generic.PHP.RequireStrictTypes"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,WordPress.Files.FileName"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Universal.WhiteSpace.PrecisionAlignment"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Squiz.WhiteSpace.SuperfluousWhitespace"
+
+# A block is a fixture, not production code. Snippets exist to set up a
+# scenario, run inside a throwaway WordPress installation, are written to be
+# read at a glance, and are routinely a single class or function on their own.
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,WordPress.NamingConventions.PrefixAllGlobals"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,WordPress.WP.GlobalVariablesOverride"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,WordPress.PHP.YodaConditions"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Universal.Files.SeparateFunctionsFromOO"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Generic.Files.OneObjectStructurePerFile"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Universal.Namespaces.OneDeclarationPerFile"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Universal.Namespaces.DisallowCurlyBraceSyntax"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Universal.Namespaces.DisallowDeclarationWithoutName"
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,PSR2.Methods.FunctionClosingBrace"
+
+# A snippet testing error handling is deliberately incomplete.
+WP_CLI_TESTS_FEATURE_EXCLUDES="$WP_CLI_TESTS_FEATURE_EXCLUDES,Generic.CodeAnalysis.EmptyStatement"
+
+WP_CLI_TESTS_FEATURE_ARGS="$WP_CLI_TESTS_FEATURE_ARGS --exclude=$WP_CLI_TESTS_FEATURE_EXCLUDES"

--- a/tests/tests/FeatureFilesTestCase.php
+++ b/tests/tests/FeatureFilesTestCase.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace WP_CLI\Tests\Tests;
+
+use WP_CLI\Tests\TestCase;
+use WP_CLI\Utils;
+
+/**
+ * Shared scaffolding for the tests of the scripts in `utils` that read the PHP
+ * blocks embedded in Behat feature files.
+ *
+ * Both scripts are stand-alone and are exercised the way they are used, by
+ * running them over a directory of feature files written into a temporary
+ * directory, so both need the same setup around them.
+ */
+abstract class FeatureFilesTestCase extends TestCase {
+
+	/**
+	 * @var string
+	 */
+	public $temp_dir;
+
+	/**
+	 * @var string
+	 */
+	public $features_dir;
+
+	/**
+	 * @var string
+	 */
+	public $target_dir;
+
+	/**
+	 * Returns the name of the script under test, relative to the `utils` directory.
+	 *
+	 * @return string Name of the script.
+	 */
+	abstract protected function get_script_name(): string;
+
+	/**
+	 * Returns the flags to run the script under test with.
+	 *
+	 * @return string[] Flags to pass to the PHP binary.
+	 */
+	abstract protected function get_php_flags(): array;
+
+	protected function set_up(): void {
+		parent::set_up();
+
+		$prefix = 'wp-cli-test-' . basename( $this->get_script_name(), '.php' ) . '-';
+
+		$this->temp_dir     = Utils\get_temp_dir() . uniqid( $prefix, true );
+		$this->features_dir = $this->temp_dir . '/features';
+		$this->target_dir   = $this->temp_dir . '/extracted';
+
+		mkdir( $this->temp_dir );
+		mkdir( $this->features_dir );
+	}
+
+	protected function tear_down(): void {
+		if ( is_dir( $this->temp_dir ) ) {
+			$this->remove_dir( $this->temp_dir );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Recursively removes a directory and its contents.
+	 *
+	 * @param string $dir The directory to remove.
+	 */
+	private function remove_dir( $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( $file->isDir() ) {
+				rmdir( $file->getPathname() );
+			} else {
+				unlink( $file->getPathname() );
+			}
+		}
+
+		rmdir( $dir );
+	}
+
+	/**
+	 * Runs the script under test from within the temporary directory.
+	 *
+	 * @param string[] $args Arguments to pass to the script.
+	 * @return array{output: string, exit_code: int} Combined output and exit code of the script.
+	 */
+	protected function run_script( array $args ): array {
+		$script = dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'utils' . DIRECTORY_SEPARATOR . $this->get_script_name();
+
+		$command = escapeshellarg( PHP_BINARY );
+
+		foreach ( $this->get_php_flags() as $flag ) {
+			$command .= ' ' . $flag;
+		}
+
+		$command .= ' ' . escapeshellarg( $script );
+
+		foreach ( $args as $arg ) {
+			$command .= ' ' . escapeshellarg( $arg );
+		}
+
+		$cd_command = Utils\is_windows() ? 'cd /d ' : 'cd ';
+		$command    = $cd_command . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
+
+		$output    = array();
+		$exit_code = 0;
+
+		exec( $command, $output, $exit_code );
+
+		return array(
+			'output'    => implode( "\n", $output ),
+			'exit_code' => $exit_code,
+		);
+	}
+
+	/**
+	 * Creates a feature file in the features directory.
+	 *
+	 * @param string $relative_path Path relative to the features directory.
+	 * @param string $contents      Contents of the feature file.
+	 * @return string Full path to the created file.
+	 */
+	protected function create_feature_file( $relative_path, $contents ): string {
+		$path = $this->features_dir . '/' . $relative_path;
+
+		$directory = dirname( $path );
+		if ( ! is_dir( $directory ) ) {
+			mkdir( $directory, 0777, true );
+		}
+
+		file_put_contents( $path, $contents );
+
+		return $path;
+	}
+
+	/**
+	 * Returns the paths of all extracted files, relative to the target directory.
+	 *
+	 * Extraction only ever writes `.php` files, so anything else in the target
+	 * directory was put there by something other than the script under test.
+	 *
+	 * @return string[] Sorted list of relative file paths.
+	 */
+	protected function get_extracted_files(): array {
+		if ( ! is_dir( $this->target_dir ) ) {
+			return array();
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $this->target_dir, \FilesystemIterator::SKIP_DOTS )
+		);
+
+		$files = array();
+
+		foreach ( $iterator as $file ) {
+			if ( $file->isFile() && 'php' === $file->getExtension() ) {
+				$files[] = str_replace( '\\', '/', substr( $file->getPathname(), strlen( $this->target_dir ) + 1 ) );
+			}
+		}
+
+		sort( $files );
+
+		return $files;
+	}
+
+	/**
+	 * Returns the contents of an extracted file.
+	 *
+	 * @param string $relative_path Path relative to the target directory.
+	 * @return string Contents of the file.
+	 */
+	protected function get_extracted_contents( $relative_path ): string {
+		$contents = file_get_contents( $this->target_dir . '/' . $relative_path );
+
+		return false === $contents ? '' : $contents;
+	}
+}

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -4,6 +4,9 @@ namespace WP_CLI\Tests\Tests;
 
 class TestExtractFeaturePhp extends FeatureFilesTestCase {
 
+	/**
+	 * @return string Name of the script.
+	 */
 	protected function get_script_name(): string {
 		return 'extract-feature-php.php';
 	}
@@ -11,6 +14,8 @@ class TestExtractFeaturePhp extends FeatureFilesTestCase {
 	/**
 	 * The script needs nothing beyond the PHP core, so `php.ini` is left out of
 	 * the run to keep the environment it is exercised in predictable.
+	 *
+	 * @return string[] Flags to pass to the PHP binary.
 	 */
 	protected function get_php_flags(): array {
 		return array( '-n' );

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -84,7 +84,8 @@ class TestExtractFeaturePhp extends TestCase {
 			$command .= ' ' . escapeshellarg( $arg );
 		}
 
-		$command = 'cd ' . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
+		$cd_command = Utils\is_windows() ? 'cd /d ' : 'cd ';
+		$command    = $cd_command . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
 
 		$output    = array();
 		$exit_code = 0;
@@ -235,6 +236,14 @@ class TestExtractFeaturePhp extends TestCase {
 			),
 			$this->get_extracted_files()
 		);
+		$this->assertSame(
+			"\n\n\n\n\n<?php\n\$foo = 'bar';\n",
+			$this->get_extracted_contents( 'example.feature_L5_E8_HASPHP.php' )
+		);
+		$this->assertSame(
+			"\n\n\n\n\n\n\n\n\n\n<?php\n\$baz = 'qux';\n",
+			$this->get_extracted_contents( 'example.feature_L10_E13_HASPHP.php' )
+		);
 	}
 
 	public function test_extracts_from_nested_directories(): void {
@@ -366,21 +375,50 @@ class TestExtractFeaturePhp extends TestCase {
 	}
 
 	public function test_extraction_refuses_to_use_the_current_directory_as_target(): void {
-		$this->create_feature_file(
-			'example.feature',
-			"Feature: Example\n"
+		$contents = "Feature: Example\n"
 			. "  Scenario: A PHP block\n"
 			. "    Given a test.php file:\n"
 			. "      \"\"\"\n"
 			. "      <?php\n"
 			. "      \$foo = 'bar';\n"
-			. "      \"\"\"\n"
-		);
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
 
 		$result = $this->run_script( array( 'extract', 'features', '.' ) );
 
 		$this->assertSame( 1, $result['exit_code'] );
 		$this->assertDirectoryExists( $this->features_dir );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+
+		$extracted_files = array();
+		$iterator        = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $this->temp_dir, \FilesystemIterator::SKIP_DOTS )
+		);
+		foreach ( $iterator as $file ) {
+			if ( $file->isFile() && 'php' === $file->getExtension() ) {
+				$extracted_files[] = $file->getPathname();
+			}
+		}
+		$this->assertSame( array(), $extracted_files );
+	}
+
+	public function test_extraction_reports_unterminated_docstring(): void {
+		$this->create_feature_file(
+			'unterminated.feature',
+			"Feature: Unterminated\n"
+			. "  Scenario: Unterminated docstring\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Unterminated docstring', $result['output'] );
+		$this->assertSame( array(), $this->get_extracted_files() );
 	}
 
 	public function test_directories_are_not_mistaken_for_an_action(): void {

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -523,4 +523,50 @@ class TestExtractFeaturePhp extends TestCase {
 		$this->assertSame( 1, $result['exit_code'] );
 		$this->assertSame( $contents, file_get_contents( $feature_file ) );
 	}
+
+	public function test_update_reports_missing_feature_file(): void {
+		$feature_file = $this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		unlink( $feature_file );
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'does not exist', $result['output'] );
+	}
+
+	public function test_update_skips_block_when_source_coordinates_mismatch(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		// Modify the feature file so the step preceding the docstring no longer creates a PHP file.
+		$modified_contents = str_replace( 'Given a test.php file:', 'Given a non-php step:', $contents );
+		file_put_contents( $feature_file, $modified_contents );
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Unexpected content in', $result['output'] );
+		$this->assertSame( $modified_contents, file_get_contents( $feature_file ) );
+	}
 }

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -1,0 +1,526 @@
+<?php
+
+namespace WP_CLI\Tests\Tests;
+
+use WP_CLI\Tests\TestCase;
+use WP_CLI\Utils;
+
+// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+class TestExtractFeaturePhp extends TestCase {
+
+	/**
+	 * @var string
+	 */
+	public $temp_dir;
+
+	/**
+	 * @var string
+	 */
+	public $features_dir;
+
+	/**
+	 * @var string
+	 */
+	public $target_dir;
+
+	protected function set_up(): void {
+		parent::set_up();
+
+		$this->temp_dir     = Utils\get_temp_dir() . uniqid( 'wp-cli-test-extract-feature-php-', true );
+		$this->features_dir = $this->temp_dir . '/features';
+		$this->target_dir   = $this->temp_dir . '/extracted';
+
+		mkdir( $this->temp_dir );
+		mkdir( $this->features_dir );
+	}
+
+	protected function tear_down(): void {
+		if ( is_dir( $this->temp_dir ) ) {
+			$this->remove_dir( $this->temp_dir );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Recursively removes a directory and its contents.
+	 *
+	 * @param string $dir The directory to remove.
+	 */
+	private function remove_dir( $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( $file->isDir() ) {
+				rmdir( $file->getPathname() );
+			} else {
+				unlink( $file->getPathname() );
+			}
+		}
+
+		rmdir( $dir );
+	}
+
+	/**
+	 * Runs the extract-feature-php.php script from within the temporary directory.
+	 *
+	 * @param string[] $args Arguments to pass to the script.
+	 * @return array{output: string, exit_code: int} Combined output and exit code of the script.
+	 */
+	private function run_script( array $args ): array {
+		$script = dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'utils' . DIRECTORY_SEPARATOR . 'extract-feature-php.php';
+
+		// Use the `-n` flag to disable loading of `php.ini` and ensure a clean environment.
+		$command = escapeshellarg( PHP_BINARY ) . ' -n ' . escapeshellarg( $script );
+
+		foreach ( $args as $arg ) {
+			$command .= ' ' . escapeshellarg( $arg );
+		}
+
+		$command = 'cd ' . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
+
+		$output    = array();
+		$exit_code = 0;
+
+		exec( $command, $output, $exit_code );
+
+		return array(
+			'output'    => implode( "\n", $output ),
+			'exit_code' => $exit_code,
+		);
+	}
+
+	/**
+	 * Creates a feature file in the features directory.
+	 *
+	 * @param string $relative_path Path relative to the features directory.
+	 * @param string $contents      Contents of the feature file.
+	 * @return string Full path to the created file.
+	 */
+	private function create_feature_file( $relative_path, $contents ): string {
+		$path = $this->features_dir . '/' . $relative_path;
+
+		$directory = dirname( $path );
+		if ( ! is_dir( $directory ) ) {
+			mkdir( $directory, 0777, true );
+		}
+
+		file_put_contents( $path, $contents );
+
+		return $path;
+	}
+
+	/**
+	 * Returns the paths of all extracted files, relative to the target directory.
+	 *
+	 * @return string[] Sorted list of relative file paths.
+	 */
+	private function get_extracted_files(): array {
+		if ( ! is_dir( $this->target_dir ) ) {
+			return array();
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $this->target_dir, \FilesystemIterator::SKIP_DOTS )
+		);
+
+		$files = array();
+
+		foreach ( $iterator as $file ) {
+			if ( $file->isFile() ) {
+				$files[] = str_replace( '\\', '/', substr( $file->getPathname(), strlen( $this->target_dir ) + 1 ) );
+			}
+		}
+
+		sort( $files );
+
+		return $files;
+	}
+
+	/**
+	 * Returns the contents of an extracted file.
+	 *
+	 * @param string $relative_path Path relative to the target directory.
+	 * @return string Contents of the file.
+	 */
+	private function get_extracted_contents( $relative_path ): string {
+		$contents = file_get_contents( $this->target_dir . '/' . $relative_path );
+
+		return false === $contents ? '' : $contents;
+	}
+
+	public function test_extracts_block_with_opening_tag(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array( 'example.feature_L5_E8_HASPHP.php' ), $this->get_extracted_files() );
+
+		// The block is padded with one empty line per preceding line of the
+		// feature file, so that reported line numbers keep matching.
+		$this->assertSame(
+			"\n\n\n\n\n<?php\n\$foo = 'bar';\n",
+			$this->get_extracted_contents( 'example.feature_L5_E8_HASPHP.php' )
+		);
+	}
+
+	public function test_extracts_block_without_opening_tag(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array( 'example.feature_L5_E7_NOPHP.php' ), $this->get_extracted_files() );
+
+		// The added opening tag takes the place of the docstring delimiter, so
+		// that it is not overwritten by the first line of code.
+		$this->assertSame(
+			"\n\n\n\n<?php\n\$foo = 'bar';\n",
+			$this->get_extracted_contents( 'example.feature_L5_E7_NOPHP.php' )
+		);
+	}
+
+	public function test_extracts_multiple_blocks_from_one_feature_file(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "\n"
+			. "  Scenario: Two PHP blocks\n"
+			. "    Given a first.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+			. "    And a second.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$baz = 'qux';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			array(
+				'example.feature_L10_E13_HASPHP.php',
+				'example.feature_L5_E8_HASPHP.php',
+			),
+			$this->get_extracted_files()
+		);
+	}
+
+	public function test_extracts_from_nested_directories(): void {
+		$this->create_feature_file(
+			'sub/nested.feature',
+			"Feature: Nested\n"
+			. "\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array( 'sub/nested.feature_L5_E8_HASPHP.php' ), $this->get_extracted_files() );
+	}
+
+	public function test_extraction_preserves_relative_indentation_and_empty_lines(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "\n"
+			. "      if ( true ) {\n"
+			. "      \t\$foo = 'bar';\n"
+			. "      }\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			"\n\n\n\n<?php\n\nif ( true ) {\n\t\$foo = 'bar';\n}\n",
+			$this->get_extracted_contents( 'example.feature_L4_E10_HASPHP.php' )
+		);
+	}
+
+	public function test_extraction_skips_docstrings_that_are_not_php_files(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: An expectation about a file\n"
+			. "    Then the wp-config.php file should contain:\n"
+			. "      \"\"\"\n"
+			. "      if ( defined( 'X' ) === false ) { define( 'X', true ); }\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array(), $this->get_extracted_files() );
+	}
+
+	public function test_extraction_keeps_empty_lines_before_the_opening_tag(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			"\n\n\n\n\n<?php\n\$foo = 'bar';\n",
+			$this->get_extracted_contents( 'example.feature_L4_E8_HASPHP.php' )
+		);
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_keeps_unrelated_files_in_target_directory(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		mkdir( $this->target_dir );
+		file_put_contents( $this->target_dir . '/keep-me.txt', 'important' );
+		file_put_contents( $this->target_dir . '/stale.feature_L1_E2_HASPHP.php', '<?php' );
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertFileExists( $this->target_dir . '/keep-me.txt' );
+		$this->assertSame( 'important', file_get_contents( $this->target_dir . '/keep-me.txt' ) );
+		$this->assertFileDoesNotExist( $this->target_dir . '/stale.feature_L1_E2_HASPHP.php' );
+	}
+
+	public function test_extraction_refuses_to_use_the_source_directory_as_target(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', 'features' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertFileExists( $feature_file );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_refuses_to_use_the_current_directory_as_target(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', '.' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertDirectoryExists( $this->features_dir );
+	}
+
+	public function test_directories_are_not_mistaken_for_an_action(): void {
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array( 'example.feature_L4_E7_HASPHP.php' ), $this->get_extracted_files() );
+	}
+
+	public function test_missing_arguments_are_reported(): void {
+		$result = $this->run_script( array( 'extract' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Usage:', $result['output'] );
+	}
+
+	public function test_update_syncs_fixes_back_into_the_feature_file(): void {
+		$feature_file = $this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo='bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$extracted = $this->target_dir . '/example.feature_L4_E7_HASPHP.php';
+		file_put_contents( $extracted, "\n\n\n\n<?php\n\$foo = 'bar';\n\$baz = 'qux';\n" );
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \$baz = 'qux';\n"
+			. "      \"\"\"\n",
+			file_get_contents( $feature_file )
+		);
+	}
+
+	public function test_update_does_not_add_the_generated_opening_tag(): void {
+		$feature_file = $this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      \$foo='bar';\n"
+			. "      \"\"\"\n"
+		);
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$extracted = $this->target_dir . '/example.feature_L4_E6_NOPHP.php';
+		file_put_contents( $extracted, "\n\n\n<?php\n\$foo = 'bar';\n" );
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n",
+			file_get_contents( $feature_file )
+		);
+	}
+
+	public function test_update_without_changes_leaves_the_feature_file_untouched(): void {
+		// Includes a block starting and ending with an empty line, nested
+		// directories, and code that is indented relative to the block.
+		$contents = "Feature: Example\n"
+			. "\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "\n"
+			. "      <?php\n"
+			. "      if ( true ) {\n"
+			. "      \t\$foo = 'bar';\n"
+			. "      }\n"
+			. "\n"
+			. "      \"\"\"\n"
+			. "    And a second.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$baz = 'qux';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'sub/example.feature', $contents );
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_update_reports_unexpected_content_without_changing_the_feature_file(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		// Shift the whole block, so the padding no longer lines up.
+		$extracted = $this->target_dir . '/example.feature_L4_E7_HASPHP.php';
+		file_put_contents( $extracted, "\$shifted = true;\n" . (string) file_get_contents( $extracted ) );
+
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+}

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -2,158 +2,18 @@
 
 namespace WP_CLI\Tests\Tests;
 
-use WP_CLI\Tests\TestCase;
-use WP_CLI\Utils;
+class TestExtractFeaturePhp extends FeatureFilesTestCase {
 
-class TestExtractFeaturePhp extends TestCase {
-
-	/**
-	 * @var string
-	 */
-	public $temp_dir;
-
-	/**
-	 * @var string
-	 */
-	public $features_dir;
-
-	/**
-	 * @var string
-	 */
-	public $target_dir;
-
-	protected function set_up(): void {
-		parent::set_up();
-
-		$this->temp_dir     = Utils\get_temp_dir() . uniqid( 'wp-cli-test-extract-feature-php-', true );
-		$this->features_dir = $this->temp_dir . '/features';
-		$this->target_dir   = $this->temp_dir . '/extracted';
-
-		mkdir( $this->temp_dir );
-		mkdir( $this->features_dir );
-	}
-
-	protected function tear_down(): void {
-		if ( is_dir( $this->temp_dir ) ) {
-			$this->remove_dir( $this->temp_dir );
-		}
-
-		parent::tear_down();
+	protected function get_script_name(): string {
+		return 'extract-feature-php.php';
 	}
 
 	/**
-	 * Recursively removes a directory and its contents.
-	 *
-	 * @param string $dir The directory to remove.
+	 * The script needs nothing beyond the PHP core, so `php.ini` is left out of
+	 * the run to keep the environment it is exercised in predictable.
 	 */
-	private function remove_dir( $dir ): void {
-		if ( ! is_dir( $dir ) ) {
-			return;
-		}
-
-		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
-			\RecursiveIteratorIterator::CHILD_FIRST
-		);
-
-		foreach ( $iterator as $file ) {
-			if ( $file->isDir() ) {
-				rmdir( $file->getPathname() );
-			} else {
-				unlink( $file->getPathname() );
-			}
-		}
-
-		rmdir( $dir );
-	}
-
-	/**
-	 * Runs the extract-feature-php.php script from within the temporary directory.
-	 *
-	 * @param string[] $args Arguments to pass to the script.
-	 * @return array{output: string, exit_code: int} Combined output and exit code of the script.
-	 */
-	private function run_script( array $args ): array {
-		$script = dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'utils' . DIRECTORY_SEPARATOR . 'extract-feature-php.php';
-
-		// Use the `-n` flag to disable loading of `php.ini` and ensure a clean environment.
-		$command = escapeshellarg( PHP_BINARY ) . ' -n ' . escapeshellarg( $script );
-
-		foreach ( $args as $arg ) {
-			$command .= ' ' . escapeshellarg( $arg );
-		}
-
-		$cd_command = Utils\is_windows() ? 'cd /d ' : 'cd ';
-		$command    = $cd_command . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
-
-		$output    = array();
-		$exit_code = 0;
-
-		exec( $command, $output, $exit_code );
-
-		return array(
-			'output'    => implode( "\n", $output ),
-			'exit_code' => $exit_code,
-		);
-	}
-
-	/**
-	 * Creates a feature file in the features directory.
-	 *
-	 * @param string $relative_path Path relative to the features directory.
-	 * @param string $contents      Contents of the feature file.
-	 * @return string Full path to the created file.
-	 */
-	private function create_feature_file( $relative_path, $contents ): string {
-		$path = $this->features_dir . '/' . $relative_path;
-
-		$directory = dirname( $path );
-		if ( ! is_dir( $directory ) ) {
-			mkdir( $directory, 0777, true );
-		}
-
-		file_put_contents( $path, $contents );
-
-		return $path;
-	}
-
-	/**
-	 * Returns the paths of all extracted files, relative to the target directory.
-	 *
-	 * @return string[] Sorted list of relative file paths.
-	 */
-	private function get_extracted_files(): array {
-		if ( ! is_dir( $this->target_dir ) ) {
-			return array();
-		}
-
-		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $this->target_dir, \FilesystemIterator::SKIP_DOTS )
-		);
-
-		$files = array();
-
-		foreach ( $iterator as $file ) {
-			if ( $file->isFile() ) {
-				$files[] = str_replace( '\\', '/', substr( $file->getPathname(), strlen( $this->target_dir ) + 1 ) );
-			}
-		}
-
-		sort( $files );
-
-		return $files;
-	}
-
-	/**
-	 * Returns the contents of an extracted file.
-	 *
-	 * @param string $relative_path Path relative to the target directory.
-	 * @return string Contents of the file.
-	 */
-	private function get_extracted_contents( $relative_path ): string {
-		$contents = file_get_contents( $this->target_dir . '/' . $relative_path );
-
-		return false === $contents ? '' : $contents;
+	protected function get_php_flags(): array {
+		return array( '-n' );
 	}
 
 	public function test_extracts_block_with_opening_tag(): void {

--- a/tests/tests/TestExtractFeaturePhp.php
+++ b/tests/tests/TestExtractFeaturePhp.php
@@ -5,7 +5,6 @@ namespace WP_CLI\Tests\Tests;
 use WP_CLI\Tests\TestCase;
 use WP_CLI\Utils;
 
-// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
 class TestExtractFeaturePhp extends TestCase {
 
 	/**
@@ -604,7 +603,104 @@ class TestExtractFeaturePhp extends TestCase {
 		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
 
 		$this->assertSame( 1, $result['exit_code'] );
-		$this->assertStringContainsString( 'Unexpected content in', $result['output'] );
+		$this->assertStringContainsString( 'is no longer the one that was checked', $result['output'] );
 		$this->assertSame( $modified_contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_skips_php_docstrings_that_do_not_belong_to_a_php_file_step(): void {
+		// The block opens with `<?php`, but the step it belongs to states an
+		// expectation instead of creating a file. Reformatting it would make it
+		// stop matching the file it is checked against.
+		$contents = "Feature: Example\n"
+			. "  Scenario: An expectation about a file\n"
+			. "    Then the wp-config.php file should contain:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      define('FOO',true);\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( array(), $this->get_extracted_files() );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_update_preserves_a_block_indented_below_its_opening_tag(): void {
+		// The first line of the block is not the one carrying the least
+		// indentation, so the indentation to restore cannot be read off it.
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "    \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_update_preserves_mixed_tab_and_space_indentation(): void {
+		// Extraction takes a shared prefix off the block rather than a number of
+		// characters, so a tab never comes back as a space or the other way round.
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "\tif ( true ) {}\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$this->run_script( array( 'extract', 'features', 'extracted' ) );
+		$result = $this->run_script( array( 'update', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_refuses_to_use_a_root_directory_as_target(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', '/' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Refusing to use', $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_refuses_a_target_that_only_resolves_to_a_root(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', str_repeat( '../', 64 ) ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Refusing to use', $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
 	}
 }

--- a/tests/tests/TestPhpStanFeatureFiles.php
+++ b/tests/tests/TestPhpStanFeatureFiles.php
@@ -4,12 +4,17 @@ namespace WP_CLI\Tests\Tests;
 
 class TestPhpStanFeatureFiles extends FeatureFilesTestCase {
 
+	/**
+	 * @return string Name of the script.
+	 */
 	protected function get_script_name(): string {
 		return 'phpstan-feature-files.php';
 	}
 
 	/**
 	 * `php.ini` is loaded as usual here, as the script needs ext-tokenizer.
+	 *
+	 * @return string[] Flags to pass to the PHP binary.
 	 */
 	protected function get_php_flags(): array {
 		return array();

--- a/tests/tests/TestPhpStanFeatureFiles.php
+++ b/tests/tests/TestPhpStanFeatureFiles.php
@@ -2,158 +2,17 @@
 
 namespace WP_CLI\Tests\Tests;
 
-use WP_CLI\Tests\TestCase;
-use WP_CLI\Utils;
+class TestPhpStanFeatureFiles extends FeatureFilesTestCase {
 
-class TestPhpStanFeatureFiles extends TestCase {
-
-	/**
-	 * @var string
-	 */
-	public $temp_dir;
-
-	/**
-	 * @var string
-	 */
-	public $features_dir;
-
-	/**
-	 * @var string
-	 */
-	public $target_dir;
-
-	protected function set_up(): void {
-		parent::set_up();
-
-		$this->temp_dir     = Utils\get_temp_dir() . uniqid( 'wp-cli-test-phpstan-feature-files-', true );
-		$this->features_dir = $this->temp_dir . '/features';
-		$this->target_dir   = $this->temp_dir . '/extracted';
-
-		mkdir( $this->temp_dir );
-		mkdir( $this->features_dir );
-	}
-
-	protected function tear_down(): void {
-		if ( is_dir( $this->temp_dir ) ) {
-			$this->remove_dir( $this->temp_dir );
-		}
-
-		parent::tear_down();
+	protected function get_script_name(): string {
+		return 'phpstan-feature-files.php';
 	}
 
 	/**
-	 * Recursively removes a directory and its contents.
-	 *
-	 * @param string $dir The directory to remove.
+	 * `php.ini` is loaded as usual here, as the script needs ext-tokenizer.
 	 */
-	private function remove_dir( $dir ): void {
-		if ( ! is_dir( $dir ) ) {
-			return;
-		}
-
-		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
-			\RecursiveIteratorIterator::CHILD_FIRST
-		);
-
-		foreach ( $iterator as $file ) {
-			if ( $file->isDir() ) {
-				rmdir( $file->getPathname() );
-			} else {
-				unlink( $file->getPathname() );
-			}
-		}
-
-		rmdir( $dir );
-	}
-
-	/**
-	 * Runs the phpstan-feature-files.php script from within the temporary directory.
-	 *
-	 * @param string[] $args Arguments to pass to the script.
-	 * @return array{output: string, exit_code: int} Combined output and exit code of the script.
-	 */
-	private function run_script( array $args ): array {
-		$script = dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'utils' . DIRECTORY_SEPARATOR . 'phpstan-feature-files.php';
-
-		// `php.ini` is loaded as usual here, as the script needs ext-tokenizer.
-		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script );
-
-		foreach ( $args as $arg ) {
-			$command .= ' ' . escapeshellarg( $arg );
-		}
-
-		$cd_command = Utils\is_windows() ? 'cd /d ' : 'cd ';
-		$command    = $cd_command . escapeshellarg( $this->temp_dir ) . ' && ' . $command . ' 2>&1';
-
-		$output    = array();
-		$exit_code = 0;
-
-		exec( $command, $output, $exit_code );
-
-		return array(
-			'output'    => implode( "\n", $output ),
-			'exit_code' => $exit_code,
-		);
-	}
-
-	/**
-	 * Creates a feature file in the features directory.
-	 *
-	 * @param string $relative_path Path relative to the features directory.
-	 * @param string $contents      Contents of the feature file.
-	 * @return string Full path to the created file.
-	 */
-	private function create_feature_file( $relative_path, $contents ): string {
-		$path = $this->features_dir . '/' . $relative_path;
-
-		$directory = dirname( $path );
-		if ( ! is_dir( $directory ) ) {
-			mkdir( $directory, 0777, true );
-		}
-
-		file_put_contents( $path, $contents );
-
-		return $path;
-	}
-
-	/**
-	 * Returns the paths of all extracted files, relative to the target directory.
-	 *
-	 * @return string[] Sorted list of relative file paths.
-	 */
-	private function get_extracted_files(): array {
-		if ( ! is_dir( $this->target_dir ) ) {
-			return array();
-		}
-
-		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $this->target_dir, \FilesystemIterator::SKIP_DOTS )
-		);
-
-		$files = array();
-
-		foreach ( $iterator as $file ) {
-			if ( $file->isFile() && 'php' === $file->getExtension() ) {
-				$files[] = str_replace( '\\', '/', substr( $file->getPathname(), strlen( $this->target_dir ) + 1 ) );
-			}
-		}
-
-		sort( $files );
-
-		return $files;
-	}
-
-	/**
-	 * Returns the contents of an extracted file.
-	 *
-	 * @param string $relative_path Path relative to the target directory.
-	 * @return string Contents of the file.
-	 */
-	private function get_extracted_contents( $relative_path ): string {
-		$contents = file_get_contents( $this->target_dir . '/' . $relative_path );
-
-		return false === $contents ? '' : $contents;
+	protected function get_php_flags(): array {
+		return array();
 	}
 
 	/**

--- a/tests/tests/TestPhpStanFeatureFiles.php
+++ b/tests/tests/TestPhpStanFeatureFiles.php
@@ -546,6 +546,42 @@ class TestPhpStanFeatureFiles extends TestCase {
 		$this->assertSame( $contents, file_get_contents( $feature_file ) );
 	}
 
+	public function test_extraction_refuses_to_use_a_root_directory_as_target(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', '/' ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Refusing to use', $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
+	public function test_extraction_refuses_a_target_that_only_resolves_to_a_root(): void {
+		$contents = "Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "      \$foo = 'bar';\n"
+			. "      \"\"\"\n";
+
+		$feature_file = $this->create_feature_file( 'example.feature', $contents );
+
+		$result = $this->run_script( array( 'extract', 'features', str_repeat( '../', 64 ) ) );
+
+		$this->assertSame( 1, $result['exit_code'] );
+		$this->assertStringContainsString( 'Refusing to use', $result['output'] );
+		$this->assertSame( $contents, file_get_contents( $feature_file ) );
+	}
+
 	public function test_extraction_refuses_to_use_the_current_directory_as_target(): void {
 		$contents = "Feature: Example\n"
 			. "  Scenario: A PHP block\n"

--- a/tests/tests/TestPhpStanFeatureFiles.php
+++ b/tests/tests/TestPhpStanFeatureFiles.php
@@ -546,6 +546,30 @@ class TestPhpStanFeatureFiles extends TestCase {
 		$this->assertSame( $contents, file_get_contents( $feature_file ) );
 	}
 
+	public function test_extraction_preserves_indentation_that_mixes_tabs_and_spaces(): void {
+		// The shared indentation is taken off a block as a prefix rather than as
+		// a number of characters, so a line indented with a tab where the rest of
+		// the block uses spaces keeps its tab instead of trading it for a space.
+		$this->create_feature_file(
+			'example.feature',
+			"Feature: Example\n"
+			. "  Scenario: A PHP block\n"
+			. "    Given a test.php file:\n"
+			. "      \"\"\"\n"
+			. "      <?php\n"
+			. "\tfoo();\n"
+			. "      \"\"\"\n"
+		);
+
+		$result = $this->run_script( array( 'extract', 'features', 'extracted' ) );
+
+		$this->assertSame( 0, $result['exit_code'], $result['output'] );
+		$this->assertSame(
+			"<?php\n\n\n\n\n\tfoo();\n",
+			$this->get_extracted_contents( 'batch0/example.feature_L4_E7.php' )
+		);
+	}
+
 	public function test_extraction_refuses_to_use_a_root_directory_as_target(): void {
 		$contents = "Feature: Example\n"
 			. "  Scenario: A PHP block\n"

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -216,7 +216,7 @@ function update_feature_php( $source_dir, $target_dir ) {
 				if ( '' === trim( $line_content ) ) {
 					$fixed_lines[] = "\n";
 				} else {
-					$fixed_lines[] = $indent . ltrim( $line_content );
+					$fixed_lines[] = $indent . $line_content;
 				}
 			}
 

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Extracts PHP snippets from Behat .feature files into line-padded standalone PHP files,
+ * and syncs PHPCBF fixes back into original .feature files.
+ */
+
+namespace WP_CLI\Tests;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Extract PHP blocks from a source directory of feature files to a target directory.
+ *
+ * @param string $source_dir Source directory containing .feature files.
+ * @param string $target_dir Target directory to output extracted .php files.
+ * @return void
+ */
+function extract_feature_php( $source_dir, $target_dir ) {
+	$source_dir = rtrim( $source_dir, '/' );
+	$target_dir = rtrim( $target_dir, '/' );
+
+	if ( ! is_dir( $source_dir ) ) {
+		return;
+	}
+
+	if ( is_dir( $target_dir ) ) {
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $files as $fileinfo ) {
+			$todo = ( $fileinfo->isDir() ? 'rmdir' : 'unlink' );
+			$todo( $fileinfo->getRealPath() );
+		}
+	}
+
+	$directory = new RecursiveDirectoryIterator( $source_dir );
+	$iterator  = new RecursiveIteratorIterator( $directory );
+
+	foreach ( $iterator as $file ) {
+		if ( $file->isFile() && 'feature' === $file->getExtension() ) {
+			$filepath = $file->getPathname();
+			$relative = substr( $filepath, strlen( $source_dir ) + 1 );
+			$lines    = file( $filepath );
+
+			$in_docstring    = false;
+			$is_php_block    = false;
+			$docstring_lines = [];
+			$start_line      = 0;
+
+			foreach ( $lines as $index => $line ) {
+				$trimmed = trim( $line );
+
+				if ( 0 === strpos( $trimmed, '"""' ) || 0 === strpos( $trimmed, "'''" ) ) {
+					if ( ! $in_docstring ) {
+						$in_docstring    = true;
+						$is_php_block    = false;
+						$docstring_lines = [];
+						$start_line      = $index;
+
+						if ( $index > 0 && preg_match( '/\b[\w\/-]+\.php\b/i', $lines[ $index - 1 ] ) ) {
+							$is_php_block = true;
+						}
+					} else {
+						$in_docstring = false;
+						if ( $is_php_block && ! empty( $docstring_lines ) ) {
+							$min_indent = PHP_INT_MAX;
+							foreach ( $docstring_lines as $code_line ) {
+								if ( '' !== trim( $code_line ) ) {
+									preg_match( '/^\s*/', $code_line, $m );
+									$min_indent = min( $min_indent, strlen( $m[0] ) );
+								}
+							}
+							if ( PHP_INT_MAX === $min_indent ) {
+								$min_indent = 0;
+							}
+
+							$has_php_tag = false;
+							foreach ( $docstring_lines as $code_line ) {
+								if ( '' !== trim( $code_line ) ) {
+									if ( 0 === strpos( trim( $code_line ), '<?php' ) ) {
+										$has_php_tag = true;
+									}
+									break;
+								}
+							}
+
+							$out_lines = [];
+							for ( $i = 0; $i < $start_line + 1; $i++ ) {
+								$out_lines[ $i ] = "\n";
+							}
+
+							if ( ! $has_php_tag ) {
+								$out_lines[ $start_line + 1 ] = "<?php // added_php_tag\n";
+							}
+
+							foreach ( $docstring_lines as $line_idx => $code_line ) {
+								$out_lines[ $line_idx ] = substr( $code_line, $min_indent );
+							}
+
+							$end_line    = $index;
+							$php_flag    = $has_php_tag ? 'HASPHP' : 'NOPHP';
+							$target_file = $target_dir . '/' . $relative . '_L' . ( $start_line + 1 ) . '_E' . ( $end_line + 1 ) . '_' . $php_flag . '.php';
+
+							$target_subdir = dirname( $target_file );
+							if ( ! is_dir( $target_subdir ) ) {
+								mkdir( $target_subdir, 0777, true );
+							}
+							file_put_contents( $target_file, implode( '', $out_lines ) );
+						}
+					}
+					continue;
+				}
+
+				if ( $in_docstring ) {
+					$docstring_count = count( $docstring_lines );
+					if ( 0 === $docstring_count && 0 === strpos( $trimmed, '<?php' ) ) {
+						$is_php_block = true;
+					}
+					if ( $is_php_block ) {
+						$docstring_lines[ $index ] = $line;
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Sync fixed PHP blocks from temporary directory back into original feature files.
+ *
+ * @param string $source_dir Source directory containing .feature files.
+ * @param string $target_dir Target directory containing fixed .php files.
+ * @return void
+ */
+function update_feature_php( $source_dir, $target_dir ) {
+	$source_dir = rtrim( $source_dir, '/' );
+	$target_dir = rtrim( $target_dir, '/' );
+
+	if ( ! is_dir( $target_dir ) ) {
+		return;
+	}
+
+	$directory = new RecursiveDirectoryIterator( $target_dir );
+	$iterator  = new RecursiveIteratorIterator( $directory );
+
+	$files_by_feature = [];
+
+	foreach ( $iterator as $file ) {
+		if ( $file->isFile() && 'php' === $file->getExtension() ) {
+			$temp_filepath = $file->getPathname();
+			$temp_filename = $file->getFilename();
+
+			if ( ! preg_match( '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/', $temp_filename, $matches ) ) {
+				continue;
+			}
+
+			$sub_path         = substr( dirname( $temp_filepath ), strlen( $target_dir ) );
+			$feature_rel_path = ( '' !== $sub_path ? $sub_path . '/' : '' ) . $matches[1];
+			$feature_path     = $source_dir . '/' . ltrim( $feature_rel_path, '/' );
+
+			$files_by_feature[ $feature_path ][] = [
+				'temp_filepath'   => $temp_filepath,
+				'docstring_start' => (int) $matches[2] - 1,
+				'docstring_end'   => (int) $matches[3] - 1,
+				'had_php_tag'     => 'HASPHP' === $matches[4],
+			];
+		}
+	}
+
+	foreach ( $files_by_feature as $feature_path => $blocks ) {
+		if ( ! file_exists( $feature_path ) ) {
+			continue;
+		}
+
+		usort(
+			$blocks,
+			function ( $a, $b ) {
+				return $b['docstring_start'] <=> $a['docstring_start'];
+			}
+		);
+
+		$feature_lines = file( $feature_path );
+
+		foreach ( $blocks as $block ) {
+			$code_start  = $block['docstring_start'] + 1;
+			$code_end    = $block['docstring_end'] - 1;
+			$had_php_tag = $block['had_php_tag'];
+			$temp_lines  = file( $block['temp_filepath'] );
+
+			if ( ! isset( $feature_lines[ $code_start ] ) || $code_start > $code_end ) {
+				continue;
+			}
+
+			preg_match( '/^\s*/', $feature_lines[ $code_start ], $m );
+			$indent = $m[0] ?? '      ';
+
+			$code_lines = [];
+			foreach ( $temp_lines as $temp_line ) {
+				if ( ! $had_php_tag && false !== strpos( $temp_line, 'added_php_tag' ) ) {
+					continue;
+				}
+				$code_lines[] = $temp_line;
+			}
+
+			while ( ! empty( $code_lines ) && '' === trim( reset( $code_lines ) ) ) {
+				array_shift( $code_lines );
+			}
+			while ( ! empty( $code_lines ) && '' === trim( end( $code_lines ) ) ) {
+				array_pop( $code_lines );
+			}
+
+			$fixed_lines = [];
+			foreach ( $code_lines as $line_content ) {
+				if ( '' === trim( $line_content ) ) {
+					$fixed_lines[] = "\n";
+				} else {
+					$fixed_lines[] = $indent . ltrim( $line_content );
+				}
+			}
+
+			$num_code_lines = ( $code_end - $code_start + 1 );
+			array_splice( $feature_lines, $code_start, $num_code_lines, $fixed_lines );
+		}
+
+		file_put_contents( $feature_path, implode( '', $feature_lines ) );
+	}
+}
+
+$wp_cli_tests_action = $argv[1] ?? 'extract';
+if ( 'update' === $wp_cli_tests_action ) {
+	update_feature_php( $argv[2] ?? '', $argv[3] ?? '' );
+} else {
+	extract_feature_php( $argv[2] ?? $argv[1] ?? '', $argv[3] ?? $argv[2] ?? '' );
+}

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -96,7 +96,11 @@ function extract_feature_php( $source_dir, $target_dir ) {
 							}
 
 							foreach ( $docstring_lines as $line_idx => $code_line ) {
-								$out_lines[ $line_idx ] = substr( $code_line, $min_indent );
+								if ( '' === trim( $code_line ) ) {
+									$out_lines[ $line_idx ] = "\n";
+								} else {
+									$out_lines[ $line_idx ] = substr( $code_line, $min_indent );
+								}
 							}
 
 							$end_line    = $index;

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -6,131 +6,15 @@
 
 namespace WP_CLI\Tests;
 
-use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+
+require_once __DIR__ . '/feature-php-blocks.php';
 
 /**
  * Pattern matching the file names created during extraction.
  */
 const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/';
-
-/**
- * Determine whether a path is the root of a filesystem or of a drive.
- *
- * @param string $path Path to check.
- * @return bool Whether the path is a root directory.
- */
-function is_root_dir( $path ) {
-	if ( '' === $path ) {
-		return false;
-	}
-
-	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
-	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $path ) ) {
-		return true;
-	}
-
-	return '' === rtrim( $path, '/\\' );
-}
-
-/**
- * Determine whether a directory can be used as extraction target.
- *
- * Extraction removes previously extracted files from the target directory,
- * so guard against pointing it at a directory holding actual project files.
- *
- * @param string $target_dir Target directory to output extracted .php files.
- * @param string $source_dir Source directory containing .feature files.
- * @return bool Whether the target directory can be used.
- */
-function is_valid_target_dir( $target_dir, $source_dir ) {
-	if ( '' === $target_dir || '.' === $target_dir || '..' === $target_dir ) {
-		return false;
-	}
-
-	if ( is_root_dir( $target_dir ) ) {
-		return false;
-	}
-
-	$target_real = realpath( $target_dir );
-
-	// Also covers a path that only resolves to a root, such as `features/../..`.
-	if ( false !== $target_real && is_root_dir( $target_real ) ) {
-		return false;
-	}
-
-	// A directory that does not exist yet gets created during extraction.
-	if ( false === $target_real ) {
-		return true;
-	}
-
-	$cwd = getcwd();
-	if ( false !== $cwd && realpath( $cwd ) === $target_real ) {
-		return false;
-	}
-
-	$source_real = realpath( $source_dir );
-	if ( false === $source_real ) {
-		return true;
-	}
-
-	if ( $source_real === $target_real ) {
-		return false;
-	}
-
-	// The target directory contains the feature files themselves. A root
-	// directory already ends in a separator, so appending another one would
-	// keep the comparison below from ever matching it.
-	$target_prefix = rtrim( $target_real, '/\\' ) . DIRECTORY_SEPARATOR;
-	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_prefix ) ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Remove files of a previous extraction from the target directory.
- *
- * Only files created by this script are removed, so that an unrelated file in
- * the target directory is never lost. Directories are removed once they are
- * empty, which includes an empty directory that was already there.
- *
- * @param string $target_dir Target directory containing extracted .php files.
- * @return void
- */
-function remove_extracted_files( $target_dir ) {
-	if ( ! is_dir( $target_dir ) ) {
-		return;
-	}
-
-	// The caller is expected to have rejected such a directory already, but
-	// the walk below is not something to start on a whole filesystem by
-	// accident.
-	$target_real = realpath( $target_dir );
-	if ( is_root_dir( $target_dir ) || ( false !== $target_real && is_root_dir( $target_real ) ) ) {
-		return;
-	}
-
-	$files = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
-		RecursiveIteratorIterator::CHILD_FIRST
-	);
-
-	foreach ( $files as $fileinfo ) {
-		$pathname = $fileinfo->getPathname();
-
-		if ( $fileinfo->isDir() ) {
-			$contents = new FilesystemIterator( $pathname );
-			if ( ! $contents->valid() ) {
-				rmdir( $pathname );
-			}
-		} elseif ( preg_match( EXTRACTED_FILE_PATTERN, $fileinfo->getFilename() ) ) {
-			unlink( $pathname );
-		}
-	}
-}
 
 /**
  * Determine the indentation that all lines holding code share.
@@ -174,26 +58,6 @@ function get_common_indent( array $lines ) {
 }
 
 /**
- * Determine whether a step creates a PHP file.
- *
- * The docstring following such a step holds the contents of a PHP file, while
- * docstrings following other steps -- an expectation about the contents of a
- * file, for example -- are not necessarily PHP code and must not be touched.
- *
- * This is the only thing that makes a docstring a PHP block here. The analysis
- * in `phpstan-feature-files.php` also takes one that opens with `<?php`, which
- * it can afford because it only ever reads. Reformatting an expectation would
- * make it stop matching the file it is checked against, so a block that is
- * fixed in place has to be one whose contents are known to be a PHP file.
- *
- * @param string $line Line preceding a docstring.
- * @return bool Whether the line is a step creating a PHP file.
- */
-function is_php_file_step( $line ) {
-	return 1 === preg_match( '/^\s*(?:Given|When|Then|And|But|\*)\s+an?\s+[\w\/.-]+\.php\s+(?:cache\s+)?file:\s*$/i', $line );
-}
-
-/**
  * Extract PHP blocks from a source directory of feature files to a target directory.
  *
  * @param string $source_dir Source directory containing .feature files.
@@ -214,7 +78,7 @@ function extract_feature_php( $source_dir, $target_dir ) {
 		return false;
 	}
 
-	remove_extracted_files( $target_dir );
+	remove_extracted_files( $target_dir, EXTRACTED_FILE_PATTERN );
 
 	$success = true;
 

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -30,8 +30,8 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 		return false;
 	}
 
-	// A Windows drive root, such as `C:` or `C:\`.
-	if ( preg_match( '/^[a-z]:\\\\?$/i', $target_dir ) ) {
+	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
+	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $target_dir ) ) {
 		return false;
 	}
 
@@ -119,8 +119,8 @@ function is_php_file_step( $line ) {
  * @return bool Whether extraction completed successfully.
  */
 function extract_feature_php( $source_dir, $target_dir ) {
-	$source_dir = rtrim( $source_dir, '/' );
-	$target_dir = rtrim( $target_dir, '/' );
+	$source_dir = rtrim( str_replace( '\\', '/', $source_dir ), '/' );
+	$target_dir = rtrim( str_replace( '\\', '/', $target_dir ), '/' );
 
 	if ( ! is_dir( $source_dir ) ) {
 		fwrite( STDERR, sprintf( 'Source directory "%s" does not exist.', $source_dir ) . PHP_EOL );
@@ -141,7 +141,7 @@ function extract_feature_php( $source_dir, $target_dir ) {
 
 	foreach ( $iterator as $file ) {
 		if ( $file->isFile() && 'feature' === $file->getExtension() ) {
-			$filepath = $file->getPathname();
+			$filepath = str_replace( '\\', '/', $file->getPathname() );
 			$relative = substr( $filepath, strlen( $source_dir ) + 1 );
 			$lines    = file( $filepath );
 
@@ -327,8 +327,8 @@ function strip_extraction_padding( $temp_lines, $code_start, $had_php_tag ) {
  * @return bool Whether all blocks were synced successfully.
  */
 function update_feature_php( $source_dir, $target_dir ) {
-	$source_dir = rtrim( $source_dir, '/' );
-	$target_dir = rtrim( $target_dir, '/' );
+	$source_dir = rtrim( str_replace( '\\', '/', $source_dir ), '/' );
+	$target_dir = rtrim( str_replace( '\\', '/', $target_dir ), '/' );
 
 	if ( ! is_dir( $target_dir ) ) {
 		fwrite( STDERR, sprintf( 'Target directory "%s" does not exist.', $target_dir ) . PHP_EOL );
@@ -342,7 +342,7 @@ function update_feature_php( $source_dir, $target_dir ) {
 
 	foreach ( $iterator as $file ) {
 		if ( $file->isFile() && 'php' === $file->getExtension() ) {
-			$temp_filepath = $file->getPathname();
+			$temp_filepath = str_replace( '\\', '/', $file->getPathname() );
 			$temp_filename = $file->getFilename();
 
 			if ( ! preg_match( EXTRACTED_FILE_PATTERN, $temp_filename, $matches ) ) {
@@ -366,6 +366,8 @@ function update_feature_php( $source_dir, $target_dir ) {
 
 	foreach ( $files_by_feature as $feature_path => $blocks ) {
 		if ( ! file_exists( $feature_path ) ) {
+			fwrite( STDERR, sprintf( 'Feature file "%s" does not exist.', $feature_path ) . PHP_EOL );
+			$success = false;
 			continue;
 		}
 
@@ -385,9 +387,11 @@ function update_feature_php( $source_dir, $target_dir ) {
 		}
 
 		foreach ( $blocks as $block ) {
-			$code_start = $block['docstring_start'] + 1;
-			$code_end   = $block['docstring_end'] - 1;
-			$temp_lines = file( $block['temp_filepath'] );
+			$docstring_start = $block['docstring_start'];
+			$docstring_end   = $block['docstring_end'];
+			$code_start      = $docstring_start + 1;
+			$code_end        = $docstring_end - 1;
+			$temp_lines      = file( $block['temp_filepath'] );
 
 			if ( false === $temp_lines ) {
 				fwrite( STDERR, sprintf( 'Could not read "%s".', $block['temp_filepath'] ) . PHP_EOL );
@@ -395,7 +399,21 @@ function update_feature_php( $source_dir, $target_dir ) {
 				continue;
 			}
 
-			if ( ! isset( $feature_lines[ $code_start ] ) || $code_start > $code_end ) {
+			if (
+				$code_start > $code_end
+				|| ! isset( $feature_lines[ $docstring_start ] )
+				|| ! isset( $feature_lines[ $docstring_end ] )
+				|| ( 0 !== strpos( trim( $feature_lines[ $docstring_start ] ), '"""' ) && 0 !== strpos( trim( $feature_lines[ $docstring_start ] ), "'''" ) )
+				|| ( 0 !== strpos( trim( $feature_lines[ $docstring_end ] ), '"""' ) && 0 !== strpos( trim( $feature_lines[ $docstring_end ] ), "'''" ) )
+				|| 0 === $docstring_start
+				|| ! isset( $feature_lines[ $docstring_start - 1 ] )
+				|| ! is_php_file_step( $feature_lines[ $docstring_start - 1 ] )
+			) {
+				fwrite(
+					STDERR,
+					sprintf( 'Unexpected content in "%s", not syncing this block.', $feature_path ) . PHP_EOL
+				);
+				$success = false;
 				continue;
 			}
 

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -58,6 +58,45 @@ function get_common_indent( array $lines ) {
 }
 
 /**
+ * Turn a PHP block into the source of a standalone PHP file.
+ *
+ * The block is padded with one empty line per preceding line of the feature
+ * file, so that the line numbers PHP_CodeSniffer reports are the line numbers
+ * of the feature file. A block that does not bring its own opening tag is
+ * given one on the line of the docstring delimiter, which is the line right
+ * before the first line of code and therefore free.
+ *
+ * Unlike the analysis in `phpstan-feature-files.php`, an opening tag that the
+ * block brings along stays where it is. A fix is written back into the feature
+ * file, so the checked copy has to line up with the block it came from.
+ *
+ * @param array{start: int, lines: array<int, string>, has_php_tag: bool} $block Block to render.
+ * @return string Source of the standalone PHP file.
+ */
+function render_fixable_block( array $block ) {
+	$indent_length = strlen( (string) get_common_indent( $block['lines'] ) );
+
+	$out_lines = [];
+	for ( $i = 0; $i < $block['start'] + 1; $i++ ) {
+		$out_lines[ $i ] = "\n";
+	}
+
+	if ( ! $block['has_php_tag'] ) {
+		$out_lines[ $block['start'] ] = "<?php\n";
+	}
+
+	foreach ( $block['lines'] as $line_idx => $code_line ) {
+		if ( '' === trim( $code_line ) ) {
+			$out_lines[ $line_idx ] = "\n";
+		} else {
+			$out_lines[ $line_idx ] = substr( $code_line, $indent_length );
+		}
+	}
+
+	return implode( '', $out_lines );
+}
+
+/**
  * Extract PHP blocks from a source directory of feature files to a target directory.
  *
  * @param string $source_dir Source directory containing .feature files.
@@ -82,102 +121,44 @@ function extract_feature_php( $source_dir, $target_dir ) {
 
 	$success = true;
 
-	$directory = new RecursiveDirectoryIterator( $source_dir );
-	$iterator  = new RecursiveIteratorIterator( $directory );
+	foreach ( find_feature_files( $source_dir ) as $filepath ) {
+		$relative = substr( $filepath, strlen( $source_dir ) + 1 );
+		$lines    = file( $filepath );
 
-	foreach ( $iterator as $file ) {
-		if ( $file->isFile() && 'feature' === $file->getExtension() ) {
-			$filepath = str_replace( '\\', '/', $file->getPathname() );
-			$relative = substr( $filepath, strlen( $source_dir ) + 1 );
-			$lines    = file( $filepath );
+		if ( false === $lines ) {
+			fwrite( STDERR, sprintf( 'Could not read "%s".', $filepath ) . PHP_EOL );
+			$success = false;
+			continue;
+		}
 
-			if ( false === $lines ) {
-				fwrite( STDERR, sprintf( 'Could not read "%s".', $filepath ) . PHP_EOL );
+		$blocks = collect_blocks( $lines );
+
+		if ( null === $blocks ) {
+			fwrite( STDERR, sprintf( 'Unterminated docstring in "%s".', $filepath ) . PHP_EOL );
+			$success = false;
+			continue;
+		}
+
+		foreach ( $blocks as $block ) {
+			// A docstring that merely opens with `<?php` is not necessarily a
+			// PHP file, and a block is fixed in place here, so the step is what
+			// decides. See is_php_file_step().
+			if ( ! $block['from_step'] ) {
+				continue;
+			}
+
+			$php_flag    = $block['has_php_tag'] ? 'HASPHP' : 'NOPHP';
+			$target_file = $target_dir . '/' . $relative . '_L' . ( $block['start'] + 1 ) . '_E' . ( $block['end'] + 1 ) . '_' . $php_flag . '.php';
+
+			$target_subdir = dirname( $target_file );
+			if ( ! is_dir( $target_subdir ) && ! mkdir( $target_subdir, 0777, true ) && ! is_dir( $target_subdir ) ) {
+				fwrite( STDERR, sprintf( 'Could not create directory "%s".', $target_subdir ) . PHP_EOL );
 				$success = false;
 				continue;
 			}
 
-			$in_docstring    = false;
-			$is_php_block    = false;
-			$start_line      = 0;
-			$docstring_lines = [];
-
-			foreach ( $lines as $index => $line ) {
-				$trimmed = trim( $line );
-
-				if ( 0 === strpos( $trimmed, '"""' ) || 0 === strpos( $trimmed, "'''" ) ) {
-					if ( ! $in_docstring ) {
-						$in_docstring    = true;
-						$is_php_block    = false;
-						$docstring_lines = [];
-						$start_line      = $index;
-
-						if ( $index > 0 && is_php_file_step( $lines[ $index - 1 ] ) ) {
-							$is_php_block = true;
-						}
-					} else {
-						$in_docstring = false;
-						if ( $is_php_block && ! empty( $docstring_lines ) ) {
-							$indent_length = strlen( (string) get_common_indent( $docstring_lines ) );
-
-							$has_php_tag = false;
-							foreach ( $docstring_lines as $code_line ) {
-								if ( '' !== trim( $code_line ) ) {
-									if ( 0 === strpos( trim( $code_line ), '<?php' ) ) {
-										$has_php_tag = true;
-									}
-									break;
-								}
-							}
-
-							$out_lines = [];
-							for ( $i = 0; $i < $start_line + 1; $i++ ) {
-								$out_lines[ $i ] = "\n";
-							}
-
-							// The docstring delimiter is the line right before the first line of
-							// code, so an added opening tag goes there to keep line numbers intact.
-							if ( ! $has_php_tag ) {
-								$out_lines[ $start_line ] = "<?php\n";
-							}
-
-							foreach ( $docstring_lines as $line_idx => $code_line ) {
-								if ( '' === trim( $code_line ) ) {
-									$out_lines[ $line_idx ] = "\n";
-								} else {
-									$out_lines[ $line_idx ] = substr( $code_line, $indent_length );
-								}
-							}
-
-							$end_line    = $index;
-							$php_flag    = $has_php_tag ? 'HASPHP' : 'NOPHP';
-							$target_file = $target_dir . '/' . $relative . '_L' . ( $start_line + 1 ) . '_E' . ( $end_line + 1 ) . '_' . $php_flag . '.php';
-
-							$target_subdir = dirname( $target_file );
-							if ( ! is_dir( $target_subdir ) && ! mkdir( $target_subdir, 0777, true ) && ! is_dir( $target_subdir ) ) {
-								fwrite( STDERR, sprintf( 'Could not create directory "%s".', $target_subdir ) . PHP_EOL );
-								$success = false;
-								continue;
-							}
-
-							if ( false === file_put_contents( $target_file, implode( '', $out_lines ) ) ) {
-								fwrite( STDERR, sprintf( 'Could not write "%s".', $target_file ) . PHP_EOL );
-								$success = false;
-							}
-						}
-					}
-					continue;
-				}
-
-				if ( $in_docstring ) {
-					// Every line is kept, including the empty ones leading up to
-					// an opening tag, so that line numbers keep matching.
-					$docstring_lines[ $index ] = $line;
-				}
-			}
-
-			if ( $in_docstring ) {
-				fwrite( STDERR, sprintf( 'Unterminated docstring in "%s".', $filepath ) . PHP_EOL );
+			if ( false === file_put_contents( $target_file, render_fixable_block( $block ) ) ) {
+				fwrite( STDERR, sprintf( 'Could not write "%s".', $target_file ) . PHP_EOL );
 				$success = false;
 			}
 		}

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -17,47 +17,6 @@ require_once __DIR__ . '/feature-php-blocks.php';
 const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/';
 
 /**
- * Determine the indentation that all lines holding code share.
- *
- * This is what extraction takes off a block and what syncing puts back, so it
- * is determined as an actual prefix rather than as a number of characters: a
- * block mixing tabs and spaces would otherwise come back with one swapped for
- * the other. Blank lines carry no indentation of their own and are left out.
- *
- * @param string[] $lines Lines to compare.
- * @return string|null Shared indentation, or null if no line holds code.
- */
-function get_common_indent( array $lines ) {
-	$common = null;
-
-	foreach ( $lines as $line ) {
-		if ( '' === trim( $line ) ) {
-			continue;
-		}
-
-		preg_match( '/^[ \t]*/', $line, $matches );
-
-		if ( null === $common ) {
-			$common = $matches[0];
-			continue;
-		}
-
-		$length = min( strlen( $common ), strlen( $matches[0] ) );
-		while ( $length > 0 && substr( $common, 0, $length ) !== substr( $matches[0], 0, $length ) ) {
-			--$length;
-		}
-
-		$common = substr( $common, 0, $length );
-
-		if ( '' === $common ) {
-			break;
-		}
-	}
-
-	return $common;
-}
-
-/**
  * Turn a PHP block into the source of a standalone PHP file.
  *
  * The block is padded with one empty line per preceding line of the feature

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -6,34 +6,135 @@
 
 namespace WP_CLI\Tests;
 
+use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+
+/**
+ * Pattern matching the file names created during extraction.
+ */
+const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/';
+
+/**
+ * Determine whether a directory can be used as extraction target.
+ *
+ * Extraction removes previously extracted files from the target directory,
+ * so guard against pointing it at a directory holding actual project files.
+ *
+ * @param string $target_dir Target directory to output extracted .php files.
+ * @param string $source_dir Source directory containing .feature files.
+ * @return bool Whether the target directory can be used.
+ */
+function is_valid_target_dir( $target_dir, $source_dir ) {
+	if ( '' === $target_dir || '.' === $target_dir || '..' === $target_dir ) {
+		return false;
+	}
+
+	// A Windows drive root, such as `C:` or `C:\`.
+	if ( preg_match( '/^[a-z]:\\\\?$/i', $target_dir ) ) {
+		return false;
+	}
+
+	$target_real = realpath( $target_dir );
+
+	// A directory that does not exist yet gets created during extraction.
+	if ( false === $target_real ) {
+		return true;
+	}
+
+	$cwd = getcwd();
+	if ( false !== $cwd && realpath( $cwd ) === $target_real ) {
+		return false;
+	}
+
+	$source_real = realpath( $source_dir );
+	if ( false === $source_real ) {
+		return true;
+	}
+
+	if ( $source_real === $target_real ) {
+		return false;
+	}
+
+	// The target directory contains the feature files themselves.
+	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_real . DIRECTORY_SEPARATOR ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Remove files of a previous extraction from the target directory.
+ *
+ * Only files created by this script and the directories that held them are
+ * removed, so that an unrelated file in the target directory is never lost.
+ *
+ * @param string $target_dir Target directory containing extracted .php files.
+ * @return void
+ */
+function remove_extracted_files( $target_dir ) {
+	if ( ! is_dir( $target_dir ) ) {
+		return;
+	}
+
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+
+	foreach ( $files as $fileinfo ) {
+		$pathname = $fileinfo->getPathname();
+
+		if ( $fileinfo->isDir() ) {
+			$contents = new FilesystemIterator( $pathname );
+			if ( ! $contents->valid() ) {
+				rmdir( $pathname );
+			}
+		} elseif ( preg_match( EXTRACTED_FILE_PATTERN, $fileinfo->getFilename() ) ) {
+			unlink( $pathname );
+		}
+	}
+}
+
+/**
+ * Determine whether a step creates a PHP file.
+ *
+ * The docstring following such a step holds the contents of a PHP file, while
+ * docstrings following other steps -- an expectation about the contents of a
+ * file, for example -- are not necessarily PHP code and must not be touched.
+ *
+ * @param string $line Line preceding a docstring.
+ * @return bool Whether the line is a step creating a PHP file.
+ */
+function is_php_file_step( $line ) {
+	return 1 === preg_match( '/^\s*(?:Given|When|Then|And|But|\*)\s+an?\s+[\w\/.-]+\.php\s+(?:cache\s+)?file:\s*$/i', $line );
+}
 
 /**
  * Extract PHP blocks from a source directory of feature files to a target directory.
  *
  * @param string $source_dir Source directory containing .feature files.
  * @param string $target_dir Target directory to output extracted .php files.
- * @return void
+ * @return bool Whether extraction completed successfully.
  */
 function extract_feature_php( $source_dir, $target_dir ) {
 	$source_dir = rtrim( $source_dir, '/' );
 	$target_dir = rtrim( $target_dir, '/' );
 
 	if ( ! is_dir( $source_dir ) ) {
-		return;
+		fwrite( STDERR, sprintf( 'Source directory "%s" does not exist.', $source_dir ) . PHP_EOL );
+		return false;
 	}
 
-	if ( is_dir( $target_dir ) ) {
-		$files = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
-			RecursiveIteratorIterator::CHILD_FIRST
-		);
-		foreach ( $files as $fileinfo ) {
-			$todo = ( $fileinfo->isDir() ? 'rmdir' : 'unlink' );
-			$todo( $fileinfo->getRealPath() );
-		}
+	if ( ! is_valid_target_dir( $target_dir, $source_dir ) ) {
+		fwrite( STDERR, sprintf( 'Refusing to use "%s" as target directory.', $target_dir ) . PHP_EOL );
+		return false;
 	}
+
+	remove_extracted_files( $target_dir );
+
+	$success = true;
 
 	$directory = new RecursiveDirectoryIterator( $source_dir );
 	$iterator  = new RecursiveIteratorIterator( $directory );
@@ -44,10 +145,17 @@ function extract_feature_php( $source_dir, $target_dir ) {
 			$relative = substr( $filepath, strlen( $source_dir ) + 1 );
 			$lines    = file( $filepath );
 
+			if ( false === $lines ) {
+				fwrite( STDERR, sprintf( 'Could not read "%s".', $filepath ) . PHP_EOL );
+				$success = false;
+				continue;
+			}
+
 			$in_docstring    = false;
 			$is_php_block    = false;
-			$docstring_lines = [];
+			$has_content     = false;
 			$start_line      = 0;
+			$docstring_lines = [];
 
 			foreach ( $lines as $index => $line ) {
 				$trimmed = trim( $line );
@@ -56,10 +164,11 @@ function extract_feature_php( $source_dir, $target_dir ) {
 					if ( ! $in_docstring ) {
 						$in_docstring    = true;
 						$is_php_block    = false;
+						$has_content     = false;
 						$docstring_lines = [];
 						$start_line      = $index;
 
-						if ( $index > 0 && preg_match( '/\b[\w\/-]+\.php\b/i', $lines[ $index - 1 ] ) ) {
+						if ( $index > 0 && is_php_file_step( $lines[ $index - 1 ] ) ) {
 							$is_php_block = true;
 						}
 					} else {
@@ -68,7 +177,7 @@ function extract_feature_php( $source_dir, $target_dir ) {
 							$min_indent = PHP_INT_MAX;
 							foreach ( $docstring_lines as $code_line ) {
 								if ( '' !== trim( $code_line ) ) {
-									preg_match( '/^\s*/', $code_line, $m );
+									preg_match( '/^[ \t]*/', $code_line, $m );
 									$min_indent = min( $min_indent, strlen( $m[0] ) );
 								}
 							}
@@ -91,8 +200,10 @@ function extract_feature_php( $source_dir, $target_dir ) {
 								$out_lines[ $i ] = "\n";
 							}
 
+							// The docstring delimiter is the line right before the first line of
+							// code, so an added opening tag goes there to keep line numbers intact.
 							if ( ! $has_php_tag ) {
-								$out_lines[ $start_line + 1 ] = "<?php // added_php_tag\n";
+								$out_lines[ $start_line ] = "<?php\n";
 							}
 
 							foreach ( $docstring_lines as $line_idx => $code_line ) {
@@ -108,27 +219,104 @@ function extract_feature_php( $source_dir, $target_dir ) {
 							$target_file = $target_dir . '/' . $relative . '_L' . ( $start_line + 1 ) . '_E' . ( $end_line + 1 ) . '_' . $php_flag . '.php';
 
 							$target_subdir = dirname( $target_file );
-							if ( ! is_dir( $target_subdir ) ) {
-								mkdir( $target_subdir, 0777, true );
+							if ( ! is_dir( $target_subdir ) && ! mkdir( $target_subdir, 0777, true ) && ! is_dir( $target_subdir ) ) {
+								fwrite( STDERR, sprintf( 'Could not create directory "%s".', $target_subdir ) . PHP_EOL );
+								$success = false;
+								continue;
 							}
-							file_put_contents( $target_file, implode( '', $out_lines ) );
+
+							if ( false === file_put_contents( $target_file, implode( '', $out_lines ) ) ) {
+								fwrite( STDERR, sprintf( 'Could not write "%s".', $target_file ) . PHP_EOL );
+								$success = false;
+							}
 						}
 					}
 					continue;
 				}
 
 				if ( $in_docstring ) {
-					$docstring_count = count( $docstring_lines );
-					if ( 0 === $docstring_count && 0 === strpos( $trimmed, '<?php' ) ) {
+					if ( ! $has_content && 0 === strpos( $trimmed, '<?php' ) ) {
 						$is_php_block = true;
 					}
-					if ( $is_php_block ) {
-						$docstring_lines[ $index ] = $line;
+
+					if ( '' !== $trimmed ) {
+						$has_content = true;
 					}
+
+					// Every line is kept, including the empty ones leading up to
+					// an opening tag, so that line numbers keep matching.
+					$docstring_lines[ $index ] = $line;
 				}
 			}
 		}
 	}
+
+	return $success;
+}
+
+/**
+ * Determine the indentation to use for a PHP block in a feature file.
+ *
+ * Blank lines carry no indentation of their own, so the first line that holds
+ * actual code determines the indentation for the whole block.
+ *
+ * @param string[] $feature_lines   Lines of the feature file.
+ * @param int      $code_start      Index of the first line of code.
+ * @param int      $code_end        Index of the last line of code.
+ * @param int      $docstring_start Index of the opening docstring delimiter.
+ * @return string Indentation of the block.
+ */
+function get_block_indent( $feature_lines, $code_start, $code_end, $docstring_start ) {
+	for ( $i = $code_start; $i <= $code_end; $i++ ) {
+		if ( isset( $feature_lines[ $i ] ) && '' !== trim( $feature_lines[ $i ] ) ) {
+			preg_match( '/^[ \t]*/', $feature_lines[ $i ], $m );
+			return $m[0];
+		}
+	}
+
+	if ( isset( $feature_lines[ $docstring_start ] ) ) {
+		preg_match( '/^[ \t]*/', $feature_lines[ $docstring_start ], $m );
+		return $m[0];
+	}
+
+	return '      ';
+}
+
+/**
+ * Strip the padding that extraction added in front of a PHP block.
+ *
+ * Extraction pads the file with one empty line per preceding line of the
+ * feature file, optionally followed by an added PHP opening tag. Everything
+ * after that padding belongs to the block itself, including any blank lines.
+ *
+ * @param string[] $temp_lines  Lines of the extracted file.
+ * @param int      $code_start  Index of the first line of code.
+ * @param bool     $had_php_tag Whether the block already had a PHP opening tag.
+ * @return string[]|null Lines of the block, or null if the padding is not intact.
+ */
+function strip_extraction_padding( $temp_lines, $code_start, $had_php_tag ) {
+	if ( count( $temp_lines ) < $code_start ) {
+		return null;
+	}
+
+	foreach ( array_slice( $temp_lines, 0, $code_start ) as $index => $line ) {
+		$trimmed = trim( $line );
+
+		if ( '' === $trimmed ) {
+			continue;
+		}
+
+		// The opening tag added during extraction sits right before the code.
+		if ( ! $had_php_tag && $index === $code_start - 1 && 0 === strpos( $trimmed, '<?php' ) ) {
+			continue;
+		}
+
+		return null;
+	}
+
+	$code_lines = array_slice( $temp_lines, $code_start );
+
+	return empty( $code_lines ) ? null : $code_lines;
 }
 
 /**
@@ -136,14 +324,15 @@ function extract_feature_php( $source_dir, $target_dir ) {
  *
  * @param string $source_dir Source directory containing .feature files.
  * @param string $target_dir Target directory containing fixed .php files.
- * @return void
+ * @return bool Whether all blocks were synced successfully.
  */
 function update_feature_php( $source_dir, $target_dir ) {
 	$source_dir = rtrim( $source_dir, '/' );
 	$target_dir = rtrim( $target_dir, '/' );
 
 	if ( ! is_dir( $target_dir ) ) {
-		return;
+		fwrite( STDERR, sprintf( 'Target directory "%s" does not exist.', $target_dir ) . PHP_EOL );
+		return false;
 	}
 
 	$directory = new RecursiveDirectoryIterator( $target_dir );
@@ -156,7 +345,7 @@ function update_feature_php( $source_dir, $target_dir ) {
 			$temp_filepath = $file->getPathname();
 			$temp_filename = $file->getFilename();
 
-			if ( ! preg_match( '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/', $temp_filename, $matches ) ) {
+			if ( ! preg_match( EXTRACTED_FILE_PATTERN, $temp_filename, $matches ) ) {
 				continue;
 			}
 
@@ -173,6 +362,8 @@ function update_feature_php( $source_dir, $target_dir ) {
 		}
 	}
 
+	$success = true;
+
 	foreach ( $files_by_feature as $feature_path => $blocks ) {
 		if ( ! file_exists( $feature_path ) ) {
 			continue;
@@ -187,54 +378,87 @@ function update_feature_php( $source_dir, $target_dir ) {
 
 		$feature_lines = file( $feature_path );
 
+		if ( false === $feature_lines ) {
+			fwrite( STDERR, sprintf( 'Could not read "%s".', $feature_path ) . PHP_EOL );
+			$success = false;
+			continue;
+		}
+
 		foreach ( $blocks as $block ) {
-			$code_start  = $block['docstring_start'] + 1;
-			$code_end    = $block['docstring_end'] - 1;
-			$had_php_tag = $block['had_php_tag'];
-			$temp_lines  = file( $block['temp_filepath'] );
+			$code_start = $block['docstring_start'] + 1;
+			$code_end   = $block['docstring_end'] - 1;
+			$temp_lines = file( $block['temp_filepath'] );
+
+			if ( false === $temp_lines ) {
+				fwrite( STDERR, sprintf( 'Could not read "%s".', $block['temp_filepath'] ) . PHP_EOL );
+				$success = false;
+				continue;
+			}
 
 			if ( ! isset( $feature_lines[ $code_start ] ) || $code_start > $code_end ) {
 				continue;
 			}
 
-			preg_match( '/^\s*/', $feature_lines[ $code_start ], $m );
-			$indent = $m[0] ?? '      ';
+			$code_lines = strip_extraction_padding( $temp_lines, $code_start, $block['had_php_tag'] );
 
-			$code_lines = [];
-			foreach ( $temp_lines as $temp_line ) {
-				if ( ! $had_php_tag && false !== strpos( $temp_line, 'added_php_tag' ) ) {
-					continue;
-				}
-				$code_lines[] = $temp_line;
+			if ( null === $code_lines ) {
+				fwrite(
+					STDERR,
+					sprintf( 'Unexpected content in "%s", not syncing this block.', $block['temp_filepath'] ) . PHP_EOL
+				);
+				$success = false;
+				continue;
 			}
 
-			while ( ! empty( $code_lines ) && '' === trim( reset( $code_lines ) ) ) {
-				array_shift( $code_lines );
-			}
-			while ( ! empty( $code_lines ) && '' === trim( end( $code_lines ) ) ) {
-				array_pop( $code_lines );
-			}
+			$indent = get_block_indent( $feature_lines, $code_start, $code_end, $block['docstring_start'] );
 
 			$fixed_lines = [];
 			foreach ( $code_lines as $line_content ) {
 				if ( '' === trim( $line_content ) ) {
 					$fixed_lines[] = "\n";
-				} else {
-					$fixed_lines[] = $indent . $line_content;
+					continue;
 				}
+
+				$fixed_line = $indent . $line_content;
+				if ( "\n" !== substr( $fixed_line, -1 ) ) {
+					$fixed_line .= "\n";
+				}
+
+				$fixed_lines[] = $fixed_line;
 			}
 
 			$num_code_lines = ( $code_end - $code_start + 1 );
 			array_splice( $feature_lines, $code_start, $num_code_lines, $fixed_lines );
 		}
 
-		file_put_contents( $feature_path, implode( '', $feature_lines ) );
+		if ( false === file_put_contents( $feature_path, implode( '', $feature_lines ) ) ) {
+			fwrite( STDERR, sprintf( 'Could not write "%s".', $feature_path ) . PHP_EOL );
+			$success = false;
+		}
 	}
+
+	return $success;
 }
 
-$wp_cli_tests_action = $argv[1] ?? 'extract';
-if ( 'update' === $wp_cli_tests_action ) {
-	update_feature_php( $argv[2] ?? '', $argv[3] ?? '' );
-} else {
-	extract_feature_php( $argv[2] ?? $argv[1] ?? '', $argv[3] ?? $argv[2] ?? '' );
+$wp_cli_tests_args   = array_slice( $argv, 1 );
+$wp_cli_tests_action = 'extract';
+
+// Only treat the first argument as an action if it actually is one, so that
+// a source directory does not accidentally end up being used as target.
+if ( isset( $wp_cli_tests_args[0] ) && in_array( $wp_cli_tests_args[0], [ 'extract', 'update' ], true ) ) {
+	$wp_cli_tests_action = array_shift( $wp_cli_tests_args );
 }
+
+$wp_cli_tests_source = $wp_cli_tests_args[0] ?? '';
+$wp_cli_tests_target = $wp_cli_tests_args[1] ?? '';
+
+if ( '' === $wp_cli_tests_source || '' === $wp_cli_tests_target ) {
+	fwrite( STDERR, 'Usage: extract-feature-php.php [extract|update] <source-dir> <target-dir>' . PHP_EOL );
+	exit( 1 );
+}
+
+if ( 'update' === $wp_cli_tests_action ) {
+	exit( update_feature_php( $wp_cli_tests_source, $wp_cli_tests_target ) ? 0 : 1 );
+}
+
+exit( extract_feature_php( $wp_cli_tests_source, $wp_cli_tests_target ) ? 0 : 1 );

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -16,6 +16,25 @@ use RecursiveIteratorIterator;
 const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)_(HASPHP|NOPHP)\.php$/';
 
 /**
+ * Determine whether a path is the root of a filesystem or of a drive.
+ *
+ * @param string $path Path to check.
+ * @return bool Whether the path is a root directory.
+ */
+function is_root_dir( $path ) {
+	if ( '' === $path ) {
+		return false;
+	}
+
+	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
+	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $path ) ) {
+		return true;
+	}
+
+	return '' === rtrim( $path, '/\\' );
+}
+
+/**
  * Determine whether a directory can be used as extraction target.
  *
  * Extraction removes previously extracted files from the target directory,
@@ -30,12 +49,16 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 		return false;
 	}
 
-	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
-	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $target_dir ) ) {
+	if ( is_root_dir( $target_dir ) ) {
 		return false;
 	}
 
 	$target_real = realpath( $target_dir );
+
+	// Also covers a path that only resolves to a root, such as `features/../..`.
+	if ( false !== $target_real && is_root_dir( $target_real ) ) {
+		return false;
+	}
 
 	// A directory that does not exist yet gets created during extraction.
 	if ( false === $target_real ) {
@@ -56,8 +79,11 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 		return false;
 	}
 
-	// The target directory contains the feature files themselves.
-	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_real . DIRECTORY_SEPARATOR ) ) {
+	// The target directory contains the feature files themselves. A root
+	// directory already ends in a separator, so appending another one would
+	// keep the comparison below from ever matching it.
+	$target_prefix = rtrim( $target_real, '/\\' ) . DIRECTORY_SEPARATOR;
+	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_prefix ) ) {
 		return false;
 	}
 
@@ -67,14 +93,23 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 /**
  * Remove files of a previous extraction from the target directory.
  *
- * Only files created by this script and the directories that held them are
- * removed, so that an unrelated file in the target directory is never lost.
+ * Only files created by this script are removed, so that an unrelated file in
+ * the target directory is never lost. Directories are removed once they are
+ * empty, which includes an empty directory that was already there.
  *
  * @param string $target_dir Target directory containing extracted .php files.
  * @return void
  */
 function remove_extracted_files( $target_dir ) {
 	if ( ! is_dir( $target_dir ) ) {
+		return;
+	}
+
+	// The caller is expected to have rejected such a directory already, but
+	// the walk below is not something to start on a whole filesystem by
+	// accident.
+	$target_real = realpath( $target_dir );
+	if ( is_root_dir( $target_dir ) || ( false !== $target_real && is_root_dir( $target_real ) ) ) {
 		return;
 	}
 
@@ -98,11 +133,58 @@ function remove_extracted_files( $target_dir ) {
 }
 
 /**
+ * Determine the indentation that all lines holding code share.
+ *
+ * This is what extraction takes off a block and what syncing puts back, so it
+ * is determined as an actual prefix rather than as a number of characters: a
+ * block mixing tabs and spaces would otherwise come back with one swapped for
+ * the other. Blank lines carry no indentation of their own and are left out.
+ *
+ * @param string[] $lines Lines to compare.
+ * @return string|null Shared indentation, or null if no line holds code.
+ */
+function get_common_indent( array $lines ) {
+	$common = null;
+
+	foreach ( $lines as $line ) {
+		if ( '' === trim( $line ) ) {
+			continue;
+		}
+
+		preg_match( '/^[ \t]*/', $line, $matches );
+
+		if ( null === $common ) {
+			$common = $matches[0];
+			continue;
+		}
+
+		$length = min( strlen( $common ), strlen( $matches[0] ) );
+		while ( $length > 0 && substr( $common, 0, $length ) !== substr( $matches[0], 0, $length ) ) {
+			--$length;
+		}
+
+		$common = substr( $common, 0, $length );
+
+		if ( '' === $common ) {
+			break;
+		}
+	}
+
+	return $common;
+}
+
+/**
  * Determine whether a step creates a PHP file.
  *
  * The docstring following such a step holds the contents of a PHP file, while
  * docstrings following other steps -- an expectation about the contents of a
  * file, for example -- are not necessarily PHP code and must not be touched.
+ *
+ * This is the only thing that makes a docstring a PHP block here. The analysis
+ * in `phpstan-feature-files.php` also takes one that opens with `<?php`, which
+ * it can afford because it only ever reads. Reformatting an expectation would
+ * make it stop matching the file it is checked against, so a block that is
+ * fixed in place has to be one whose contents are known to be a PHP file.
  *
  * @param string $line Line preceding a docstring.
  * @return bool Whether the line is a step creating a PHP file.
@@ -153,7 +235,6 @@ function extract_feature_php( $source_dir, $target_dir ) {
 
 			$in_docstring    = false;
 			$is_php_block    = false;
-			$has_content     = false;
 			$start_line      = 0;
 			$docstring_lines = [];
 
@@ -164,7 +245,6 @@ function extract_feature_php( $source_dir, $target_dir ) {
 					if ( ! $in_docstring ) {
 						$in_docstring    = true;
 						$is_php_block    = false;
-						$has_content     = false;
 						$docstring_lines = [];
 						$start_line      = $index;
 
@@ -174,16 +254,7 @@ function extract_feature_php( $source_dir, $target_dir ) {
 					} else {
 						$in_docstring = false;
 						if ( $is_php_block && ! empty( $docstring_lines ) ) {
-							$min_indent = PHP_INT_MAX;
-							foreach ( $docstring_lines as $code_line ) {
-								if ( '' !== trim( $code_line ) ) {
-									preg_match( '/^[ \t]*/', $code_line, $m );
-									$min_indent = min( $min_indent, strlen( $m[0] ) );
-								}
-							}
-							if ( PHP_INT_MAX === $min_indent ) {
-								$min_indent = 0;
-							}
+							$indent_length = strlen( (string) get_common_indent( $docstring_lines ) );
 
 							$has_php_tag = false;
 							foreach ( $docstring_lines as $code_line ) {
@@ -210,7 +281,7 @@ function extract_feature_php( $source_dir, $target_dir ) {
 								if ( '' === trim( $code_line ) ) {
 									$out_lines[ $line_idx ] = "\n";
 								} else {
-									$out_lines[ $line_idx ] = substr( $code_line, $min_indent );
+									$out_lines[ $line_idx ] = substr( $code_line, $indent_length );
 								}
 							}
 
@@ -235,14 +306,6 @@ function extract_feature_php( $source_dir, $target_dir ) {
 				}
 
 				if ( $in_docstring ) {
-					if ( ! $has_content && 0 === strpos( $trimmed, '<?php' ) ) {
-						$is_php_block = true;
-					}
-
-					if ( '' !== $trimmed ) {
-						$has_content = true;
-					}
-
 					// Every line is kept, including the empty ones leading up to
 					// an opening tag, so that line numbers keep matching.
 					$docstring_lines[ $index ] = $line;
@@ -260,10 +323,12 @@ function extract_feature_php( $source_dir, $target_dir ) {
 }
 
 /**
- * Determine the indentation to use for a PHP block in a feature file.
+ * Determine the indentation that extraction stripped from a PHP block.
  *
- * Blank lines carry no indentation of their own, so the first line that holds
- * actual code determines the indentation for the whole block.
+ * Extraction takes the indentation that all lines of a block share off each of
+ * them, so putting a block back restores exactly that prefix. Deriving it from
+ * the first line instead would make a block whose opening tag is indented
+ * deeper than the code below it drift further to the right on every run.
  *
  * @param string[] $feature_lines   Lines of the feature file.
  * @param int      $code_start      Index of the first line of code.
@@ -272,11 +337,20 @@ function extract_feature_php( $source_dir, $target_dir ) {
  * @return string Indentation of the block.
  */
 function get_block_indent( $feature_lines, $code_start, $code_end, $docstring_start ) {
+	$code_lines = [];
+
 	for ( $i = $code_start; $i <= $code_end; $i++ ) {
-		if ( isset( $feature_lines[ $i ] ) && '' !== trim( $feature_lines[ $i ] ) ) {
-			preg_match( '/^[ \t]*/', $feature_lines[ $i ], $m );
-			return $m[0];
+		if ( isset( $feature_lines[ $i ] ) ) {
+			$code_lines[] = $feature_lines[ $i ];
 		}
+	}
+
+	// An empty prefix is a valid answer, so only a block without any code at
+	// all falls through to the guesses below.
+	$indent = get_common_indent( $code_lines );
+
+	if ( null !== $indent ) {
+		return $indent;
 	}
 
 	if ( isset( $feature_lines[ $docstring_start ] ) ) {
@@ -416,7 +490,11 @@ function update_feature_php( $source_dir, $target_dir ) {
 			) {
 				fwrite(
 					STDERR,
-					sprintf( 'Unexpected content in "%s", not syncing this block.', $feature_path ) . PHP_EOL
+					sprintf(
+						'The block at "%s" line %d is no longer the one that was checked, dropping its fixes.',
+						$feature_path,
+						$docstring_start + 1
+					) . PHP_EOL
 				);
 				$success = false;
 				continue;
@@ -427,7 +505,11 @@ function update_feature_php( $source_dir, $target_dir ) {
 			if ( null === $code_lines ) {
 				fwrite(
 					STDERR,
-					sprintf( 'Unexpected content in "%s", not syncing this block.', $block['temp_filepath'] ) . PHP_EOL
+					sprintf(
+						'The checked copy of the block at "%s" line %d is padded unexpectedly, dropping its fixes.',
+						$feature_path,
+						$docstring_start + 1
+					) . PHP_EOL
 				);
 				$success = false;
 				continue;

--- a/utils/extract-feature-php.php
+++ b/utils/extract-feature-php.php
@@ -248,6 +248,11 @@ function extract_feature_php( $source_dir, $target_dir ) {
 					$docstring_lines[ $index ] = $line;
 				}
 			}
+
+			if ( $in_docstring ) {
+				fwrite( STDERR, sprintf( 'Unterminated docstring in "%s".', $filepath ) . PHP_EOL );
+				$success = false;
+			}
 		}
 	}
 

--- a/utils/feature-php-blocks.php
+++ b/utils/feature-php-blocks.php
@@ -126,6 +126,101 @@ function is_php_file_step( $line ) {
 }
 
 /**
+ * Find the feature files of a source directory.
+ *
+ * @param string $source_dir Source directory containing .feature files.
+ * @return string[] Sorted paths of the feature files, with forward slashes.
+ */
+function find_feature_files( $source_dir ) {
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $source_dir, FilesystemIterator::SKIP_DOTS )
+	);
+
+	$feature_files = [];
+
+	foreach ( $iterator as $file ) {
+		if ( $file->isFile() && 'feature' === $file->getExtension() ) {
+			$feature_files[] = str_replace( '\\', '/', $file->getPathname() );
+		}
+	}
+
+	// A stable order keeps the results of a run comparable to those of the next.
+	sort( $feature_files );
+
+	return $feature_files;
+}
+
+/**
+ * Collect the PHP blocks contained in a single feature file.
+ *
+ * A docstring holds a PHP block when the step it belongs to creates a `.php`
+ * file, and also when it opens with `<?php`, which covers PHP files that are
+ * not named `*.php`, such as the `.maintenance` file of a WordPress install.
+ *
+ * Which of the two recognised a block is reported back rather than decided
+ * here, as a tool writing a block back cannot afford the second rule: a
+ * docstring stating an expectation about the contents of a file routinely
+ * opens with `<?php`, and reformatting one would make it stop matching the
+ * file it is checked against.
+ *
+ * @param string[] $lines Lines of the feature file.
+ * @return array<int, array{start: int, end: int, lines: array<int, string>, from_step: bool, has_php_tag: bool}>|null Blocks, or null on an unterminated docstring.
+ */
+function collect_blocks( array $lines ) {
+	$blocks          = [];
+	$in_docstring    = false;
+	$from_step       = false;
+	$has_php_tag     = false;
+	$has_content     = false;
+	$start_line      = 0;
+	$docstring_lines = [];
+
+	foreach ( $lines as $index => $line ) {
+		$trimmed = trim( $line );
+
+		if ( 0 === strpos( $trimmed, '"""' ) || 0 === strpos( $trimmed, "'''" ) ) {
+			if ( ! $in_docstring ) {
+				$in_docstring    = true;
+				$from_step       = $index > 0 && is_php_file_step( $lines[ $index - 1 ] );
+				$has_php_tag     = false;
+				$has_content     = false;
+				$docstring_lines = [];
+				$start_line      = $index;
+			} else {
+				$in_docstring = false;
+
+				if ( ( $from_step || $has_php_tag ) && ! empty( $docstring_lines ) ) {
+					$blocks[] = [
+						'start'       => $start_line,
+						'end'         => $index,
+						'lines'       => $docstring_lines,
+						'from_step'   => $from_step,
+						'has_php_tag' => $has_php_tag,
+					];
+				}
+			}
+			continue;
+		}
+
+		if ( $in_docstring ) {
+			if ( ! $has_content && 0 === strpos( $trimmed, '<?php' ) ) {
+				$has_php_tag = true;
+			}
+
+			if ( '' !== $trimmed ) {
+				$has_content = true;
+			}
+
+			// Every line is kept, including the empty ones leading up to
+			// an opening tag, so that line numbers keep matching.
+			$docstring_lines[ $index ] = $line;
+		}
+	}
+
+	return $in_docstring ? null : $blocks;
+}
+
+/**
  * Remove files of a previous extraction from the target directory.
  *
  * Only files created by this script are removed, so that an unrelated file in

--- a/utils/feature-php-blocks.php
+++ b/utils/feature-php-blocks.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Reading the PHP blocks that Behat .feature files embed in docstrings.
+ *
+ * Shared by `extract-feature-php.php`, which checks and fixes their code style,
+ * and by `phpstan-feature-files.php`, which analyses them. What the two tools do
+ * with a block differs, but they have to agree on which docstrings hold one and
+ * on where a block may be extracted to, so that lives here.
+ *
+ * The file is not part of the autoloader. Both callers are stand-alone scripts
+ * that pull it in themselves.
+ */
+
+namespace WP_CLI\Tests;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Bring a path into the form used to compare it against another path.
+ *
+ * @param string $path Path to normalize.
+ * @return string Normalized path.
+ */
+function normalize_path( $path ) {
+	$path = rtrim( str_replace( '\\', '/', $path ), '/' );
+
+	// Windows paths are not case sensitive.
+	return DIRECTORY_SEPARATOR === '\\' ? strtolower( $path ) : $path;
+}
+
+/**
+ * Determine whether a path is the root of a filesystem or of a drive.
+ *
+ * @param string $path Path to check.
+ * @return bool Whether the path is a root directory.
+ */
+function is_root_dir( $path ) {
+	if ( '' === $path ) {
+		return false;
+	}
+
+	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
+	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $path ) ) {
+		return true;
+	}
+
+	return '' === rtrim( $path, '/\\' );
+}
+
+/**
+ * Determine whether a directory can be used as extraction target.
+ *
+ * Extraction removes previously extracted files from the target directory,
+ * so guard against pointing it at a directory holding actual project files.
+ *
+ * @param string $target_dir Target directory to output extracted .php files.
+ * @param string $source_dir Source directory containing .feature files.
+ * @return bool Whether the target directory can be used.
+ */
+function is_valid_target_dir( $target_dir, $source_dir ) {
+	if ( '' === $target_dir || '.' === $target_dir || '..' === $target_dir ) {
+		return false;
+	}
+
+	if ( is_root_dir( $target_dir ) ) {
+		return false;
+	}
+
+	$target_real = realpath( $target_dir );
+
+	// Also covers a path that only resolves to a root, such as `features/../..`.
+	if ( false !== $target_real && is_root_dir( $target_real ) ) {
+		return false;
+	}
+
+	// A directory that does not exist yet gets created during extraction.
+	if ( false === $target_real ) {
+		return true;
+	}
+
+	$cwd = getcwd();
+	if ( false !== $cwd && realpath( $cwd ) === $target_real ) {
+		return false;
+	}
+
+	$source_real = realpath( $source_dir );
+	if ( false === $source_real ) {
+		return true;
+	}
+
+	if ( $source_real === $target_real ) {
+		return false;
+	}
+
+	// The target directory contains the feature files themselves. A root
+	// directory already ends in a separator, so appending another one would
+	// keep the comparison below from ever matching it.
+	$target_prefix = rtrim( $target_real, '/\\' ) . DIRECTORY_SEPARATOR;
+	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_prefix ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Determine whether a step creates a PHP file.
+ *
+ * The docstring following such a step holds the contents of a PHP file, while
+ * docstrings following other steps -- an expectation about the contents of a
+ * file, for example -- are not necessarily PHP code and must not be touched.
+ *
+ * This is the only thing that makes a docstring a PHP block here. The analysis
+ * in `phpstan-feature-files.php` also takes one that opens with `<?php`, which
+ * it can afford because it only ever reads. Reformatting an expectation would
+ * make it stop matching the file it is checked against, so a block that is
+ * fixed in place has to be one whose contents are known to be a PHP file.
+ *
+ * @param string $line Line preceding a docstring.
+ * @return bool Whether the line is a step creating a PHP file.
+ */
+function is_php_file_step( $line ) {
+	return 1 === preg_match( '/^\s*(?:Given|When|Then|And|But|\*)\s+an?\s+[\w\/.-]+\.php\s+(?:cache\s+)?file:\s*$/i', $line );
+}
+
+/**
+ * Remove files of a previous extraction from the target directory.
+ *
+ * Only files created by this script are removed, so that an unrelated file in
+ * the target directory is never lost. Directories are removed once they are
+ * empty, which includes an empty directory that was already there.
+ *
+ * @param string $target_dir Target directory containing extracted .php files.
+ * @param string $pattern    Pattern matching the names of the extracted files.
+ * @return void
+ */
+function remove_extracted_files( $target_dir, $pattern ) {
+	if ( ! is_dir( $target_dir ) ) {
+		return;
+	}
+
+	// The caller is expected to have rejected such a directory already, but
+	// the walk below is not something to start on a whole filesystem by
+	// accident.
+	$target_real = realpath( $target_dir );
+	if ( is_root_dir( $target_dir ) || ( false !== $target_real && is_root_dir( $target_real ) ) ) {
+		return;
+	}
+
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+
+	foreach ( $files as $fileinfo ) {
+		$pathname = $fileinfo->getPathname();
+
+		if ( $fileinfo->isDir() ) {
+			$contents = new FilesystemIterator( $pathname );
+			if ( ! $contents->valid() ) {
+				rmdir( $pathname );
+			}
+		} elseif ( preg_match( $pattern, $fileinfo->getFilename() ) ) {
+			unlink( $pathname );
+		}
+	}
+}

--- a/utils/feature-php-blocks.php
+++ b/utils/feature-php-blocks.php
@@ -151,6 +151,47 @@ function find_feature_files( $source_dir ) {
 }
 
 /**
+ * Determine the indentation that all lines holding code share.
+ *
+ * This is what extraction takes off a block and what syncing puts back, so it
+ * is determined as an actual prefix rather than as a number of characters: a
+ * block mixing tabs and spaces would otherwise come back with one swapped for
+ * the other. Blank lines carry no indentation of their own and are left out.
+ *
+ * @param string[] $lines Lines to compare.
+ * @return string|null Shared indentation, or null if no line holds code.
+ */
+function get_common_indent( array $lines ) {
+	$common = null;
+
+	foreach ( $lines as $line ) {
+		if ( '' === trim( $line ) ) {
+			continue;
+		}
+
+		preg_match( '/^[ \t]*/', $line, $matches );
+
+		if ( null === $common ) {
+			$common = $matches[0];
+			continue;
+		}
+
+		$length = min( strlen( $common ), strlen( $matches[0] ) );
+		while ( $length > 0 && substr( $common, 0, $length ) !== substr( $matches[0], 0, $length ) ) {
+			--$length;
+		}
+
+		$common = substr( $common, 0, $length );
+
+		if ( '' === $common ) {
+			break;
+		}
+	}
+
+	return $common;
+}
+
+/**
  * Collect the PHP blocks contained in a single feature file.
  *
  * A docstring holds a PHP block when the step it belongs to creates a `.php`

--- a/utils/phpstan-feature-files.php
+++ b/utils/phpstan-feature-files.php
@@ -17,6 +17,8 @@ use ParseError;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
+require_once __DIR__ . '/feature-php-blocks.php';
+
 /**
  * Pattern matching the file names created during extraction.
  */
@@ -26,155 +28,6 @@ const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)\.php$/';
  * Name of the manifest describing an extraction.
  */
 const MANIFEST_FILE = 'manifest.json';
-
-/**
- * Bring a path into the form used to compare it against another path.
- *
- * @param string $path Path to normalize.
- * @return string Normalized path.
- */
-function normalize_path( $path ) {
-	$path = rtrim( str_replace( '\\', '/', $path ), '/' );
-
-	// Windows paths are not case sensitive.
-	return DIRECTORY_SEPARATOR === '\\' ? strtolower( $path ) : $path;
-}
-
-/**
- * Determine whether a path is the root of a filesystem or of a drive.
- *
- * @param string $path Path to check.
- * @return bool Whether the path is a root directory.
- */
-function is_root_dir( $path ) {
-	if ( '' === $path ) {
-		return false;
-	}
-
-	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
-	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $path ) ) {
-		return true;
-	}
-
-	return '' === rtrim( $path, '/\\' );
-}
-
-/**
- * Determine whether a directory can be used as extraction target.
- *
- * Extraction removes previously extracted files from the target directory,
- * so guard against pointing it at a directory holding actual project files.
- *
- * @param string $target_dir Target directory to output extracted .php files.
- * @param string $source_dir Source directory containing .feature files.
- * @return bool Whether the target directory can be used.
- */
-function is_valid_target_dir( $target_dir, $source_dir ) {
-	if ( '' === $target_dir || '.' === $target_dir || '..' === $target_dir ) {
-		return false;
-	}
-
-	if ( is_root_dir( $target_dir ) ) {
-		return false;
-	}
-
-	$target_real = realpath( $target_dir );
-
-	// Also covers a path that only resolves to a root, such as `features/../..`.
-	if ( false !== $target_real && is_root_dir( $target_real ) ) {
-		return false;
-	}
-
-	// A directory that does not exist yet gets created during extraction.
-	if ( false === $target_real ) {
-		return true;
-	}
-
-	$cwd = getcwd();
-	if ( false !== $cwd && realpath( $cwd ) === $target_real ) {
-		return false;
-	}
-
-	$source_real = realpath( $source_dir );
-	if ( false === $source_real ) {
-		return true;
-	}
-
-	if ( $source_real === $target_real ) {
-		return false;
-	}
-
-	// The target directory contains the feature files themselves. A root
-	// directory already ends in a separator, so appending another one would
-	// keep the comparison below from ever matching it.
-	$target_prefix = rtrim( $target_real, '/\\' ) . DIRECTORY_SEPARATOR;
-	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_prefix ) ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Remove files of a previous extraction from the target directory.
- *
- * Only files created by this script and the directories that held them are
- * removed, so that an unrelated file in the target directory is never lost.
- *
- * @param string $target_dir Target directory containing extracted .php files.
- * @return void
- */
-function remove_extracted_files( $target_dir ) {
-	if ( ! is_dir( $target_dir ) ) {
-		return;
-	}
-
-	// The caller is expected to have rejected such a directory already, but
-	// the walk below is not something to start on a whole filesystem by
-	// accident.
-	$target_real = realpath( $target_dir );
-	if ( is_root_dir( $target_dir ) || ( false !== $target_real && is_root_dir( $target_real ) ) ) {
-		return;
-	}
-
-	$manifest = $target_dir . '/' . MANIFEST_FILE;
-	if ( is_file( $manifest ) ) {
-		unlink( $manifest );
-	}
-
-	$files = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator( $target_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
-		RecursiveIteratorIterator::CHILD_FIRST
-	);
-
-	foreach ( $files as $fileinfo ) {
-		$pathname = $fileinfo->getPathname();
-
-		if ( $fileinfo->isDir() ) {
-			$contents = new FilesystemIterator( $pathname );
-			if ( ! $contents->valid() ) {
-				rmdir( $pathname );
-			}
-		} elseif ( preg_match( EXTRACTED_FILE_PATTERN, $fileinfo->getFilename() ) ) {
-			unlink( $pathname );
-		}
-	}
-}
-
-/**
- * Determine whether a step creates a PHP file.
- *
- * The docstring following such a step holds the contents of a PHP file, while
- * docstrings following other steps -- an expectation about the contents of a
- * file, for example -- are not necessarily PHP code. A docstring that opens
- * with `<?php` counts as PHP either way, see collect_blocks().
- *
- * @param string $line Line preceding a docstring.
- * @return bool Whether the line is a step creating a PHP file.
- */
-function is_php_file_step( $line ) {
-	return 1 === preg_match( '/^\s*(?:Given|When|Then|And|But|\*)\s+an?\s+[\w\/.-]+\.php\s+(?:cache\s+)?file:\s*$/i', $line );
-}
 
 /**
  * Collect the PHP blocks contained in a single feature file.
@@ -462,7 +315,13 @@ function extract_feature_php( $source_dir, $target_dir ) {
 		return false;
 	}
 
-	remove_extracted_files( $target_dir );
+	// The manifest is written by this script alone, so it goes on its own.
+	$manifest = $target_dir . '/' . MANIFEST_FILE;
+	if ( is_file( $manifest ) ) {
+		unlink( $manifest );
+	}
+
+	remove_extracted_files( $target_dir, EXTRACTED_FILE_PATTERN );
 
 	$success = true;
 	$blocks  = [];

--- a/utils/phpstan-feature-files.php
+++ b/utils/phpstan-feature-files.php
@@ -12,10 +12,7 @@
 
 namespace WP_CLI\Tests;
 
-use FilesystemIterator;
 use ParseError;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 require_once __DIR__ . '/feature-php-blocks.php';
 
@@ -28,65 +25,6 @@ const EXTRACTED_FILE_PATTERN = '/^(.*\.feature)_L(\d+)_E(\d+)\.php$/';
  * Name of the manifest describing an extraction.
  */
 const MANIFEST_FILE = 'manifest.json';
-
-/**
- * Collect the PHP blocks contained in a single feature file.
- *
- * @param string[] $lines Lines of the feature file.
- * @return array<int, array{start: int, end: int, lines: array<int, string>}>|null Blocks, or null on an unterminated docstring.
- */
-function collect_blocks( array $lines ) {
-	$blocks          = [];
-	$in_docstring    = false;
-	$is_php_block    = false;
-	$has_content     = false;
-	$start_line      = 0;
-	$docstring_lines = [];
-
-	foreach ( $lines as $index => $line ) {
-		$trimmed = trim( $line );
-
-		if ( 0 === strpos( $trimmed, '"""' ) || 0 === strpos( $trimmed, "'''" ) ) {
-			if ( ! $in_docstring ) {
-				$in_docstring    = true;
-				$is_php_block    = $index > 0 && is_php_file_step( $lines[ $index - 1 ] );
-				$has_content     = false;
-				$docstring_lines = [];
-				$start_line      = $index;
-			} else {
-				$in_docstring = false;
-
-				if ( $is_php_block && ! empty( $docstring_lines ) ) {
-					$blocks[] = [
-						'start' => $start_line,
-						'end'   => $index,
-						'lines' => $docstring_lines,
-					];
-				}
-			}
-			continue;
-		}
-
-		if ( $in_docstring ) {
-			// A block opening with `<?php` is PHP no matter which step precedes
-			// it, which covers PHP files that are not named `*.php`, such as the
-			// `.maintenance` file of a WordPress installation.
-			if ( ! $has_content && 0 === strpos( $trimmed, '<?php' ) ) {
-				$is_php_block = true;
-			}
-
-			if ( '' !== $trimmed ) {
-				$has_content = true;
-			}
-
-			// Every line is kept, including the empty ones leading up to
-			// an opening tag, so that line numbers keep matching.
-			$docstring_lines[ $index ] = $line;
-		}
-	}
-
-	return $in_docstring ? null : $blocks;
-}
 
 /**
  * Turn a PHP block into the source of a standalone PHP file.
@@ -327,21 +265,8 @@ function extract_feature_php( $source_dir, $target_dir ) {
 	$blocks  = [];
 	$skipped = [];
 
-	$iterator = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator( $source_dir, FilesystemIterator::SKIP_DOTS )
-	);
-
-	$feature_files = [];
-	foreach ( $iterator as $file ) {
-		if ( $file->isFile() && 'feature' === $file->getExtension() ) {
-			$feature_files[] = str_replace( '\\', '/', $file->getPathname() );
-		}
-	}
-
-	// The order determines the batch a block ends up in, so keep it stable.
-	sort( $feature_files );
-
-	foreach ( $feature_files as $filepath ) {
+	// The order determines the batch a block ends up in, so it has to be stable.
+	foreach ( find_feature_files( $source_dir ) as $filepath ) {
 		$relative = substr( $filepath, strlen( $source_dir ) + 1 );
 		$lines    = file( $filepath );
 

--- a/utils/phpstan-feature-files.php
+++ b/utils/phpstan-feature-files.php
@@ -40,16 +40,7 @@ const MANIFEST_FILE = 'manifest.json';
  * @return string Source of the standalone PHP file.
  */
 function render_block( array $block ) {
-	$min_indent = PHP_INT_MAX;
-	foreach ( $block['lines'] as $code_line ) {
-		if ( '' !== trim( $code_line ) ) {
-			preg_match( '/^[ \t]*/', $code_line, $matches );
-			$min_indent = min( $min_indent, strlen( $matches[0] ) );
-		}
-	}
-	if ( PHP_INT_MAX === $min_indent ) {
-		$min_indent = 0;
-	}
+	$indent_length = strlen( (string) get_common_indent( $block['lines'] ) );
 
 	$out_lines = [];
 	for ( $i = 0; $i <= $block['start']; $i++ ) {
@@ -64,7 +55,7 @@ function render_block( array $block ) {
 			continue;
 		}
 
-		$code_line = substr( $code_line, $min_indent );
+		$code_line = substr( $code_line, $indent_length );
 
 		if ( ! $tag_dropped ) {
 			$tag_dropped = true;

--- a/utils/phpstan-feature-files.php
+++ b/utils/phpstan-feature-files.php
@@ -41,6 +41,25 @@ function normalize_path( $path ) {
 }
 
 /**
+ * Determine whether a path is the root of a filesystem or of a drive.
+ *
+ * @param string $path Path to check.
+ * @return bool Whether the path is a root directory.
+ */
+function is_root_dir( $path ) {
+	if ( '' === $path ) {
+		return false;
+	}
+
+	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
+	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $path ) ) {
+		return true;
+	}
+
+	return '' === rtrim( $path, '/\\' );
+}
+
+/**
  * Determine whether a directory can be used as extraction target.
  *
  * Extraction removes previously extracted files from the target directory,
@@ -55,12 +74,16 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 		return false;
 	}
 
-	// A Windows drive root, such as `C:`, `C:\`, or `C:/`.
-	if ( preg_match( '/^[a-z]:[\\\\\/]?$/i', $target_dir ) ) {
+	if ( is_root_dir( $target_dir ) ) {
 		return false;
 	}
 
 	$target_real = realpath( $target_dir );
+
+	// Also covers a path that only resolves to a root, such as `features/../..`.
+	if ( false !== $target_real && is_root_dir( $target_real ) ) {
+		return false;
+	}
 
 	// A directory that does not exist yet gets created during extraction.
 	if ( false === $target_real ) {
@@ -81,8 +104,11 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
 		return false;
 	}
 
-	// The target directory contains the feature files themselves.
-	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_real . DIRECTORY_SEPARATOR ) ) {
+	// The target directory contains the feature files themselves. A root
+	// directory already ends in a separator, so appending another one would
+	// keep the comparison below from ever matching it.
+	$target_prefix = rtrim( $target_real, '/\\' ) . DIRECTORY_SEPARATOR;
+	if ( 0 === strpos( $source_real . DIRECTORY_SEPARATOR, $target_prefix ) ) {
 		return false;
 	}
 
@@ -100,6 +126,14 @@ function is_valid_target_dir( $target_dir, $source_dir ) {
  */
 function remove_extracted_files( $target_dir ) {
 	if ( ! is_dir( $target_dir ) ) {
+		return;
+	}
+
+	// The caller is expected to have rejected such a directory already, but
+	// the walk below is not something to start on a whole filesystem by
+	// accident.
+	$target_real = realpath( $target_dir );
+	if ( is_root_dir( $target_dir ) || ( false !== $target_real && is_root_dir( $target_real ) ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Not sure yet if really worth it, will need some testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation and automatic formatting for PHP code embedded in feature files.
  - Added tooling to extract embedded PHP for checks and synchronize formatting fixes back into feature files.

- **Bug Fixes**
  - Improved temporary-file cleanup, including when checks are interrupted.
  - Preserved and reported code-quality check failures while allowing applicable checks to complete.

- **Style**
  - Standardized formatting in feature-file test scenarios.

- **Tests**
  - Added comprehensive coverage for PHP extraction, validation, formatting, and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->