### PR TITLE
Drop support for PHPUnit Polyfills v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "wp-cli/eval-command": "^1 || ^2",
         "wp-cli/wp-cli": "^2.13",
         "wp-coding-standards/wpcs": "dev-develop",
-        "yoast/phpunit-polyfills": "^1.0 || ^2.0 || ^3.0 || ^4.0"
+        "yoast/phpunit-polyfills": "^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
Drops support for `yoast/phpunit-polyfills` `^1.0`, keeping constraints to `^2.0 || ^3.0 || ^4.0`.

- `wp-cli-tests` requires PHP `>=7.2.24`, whereas `yoast/phpunit-polyfills` v2+ requires PHP 7.1+ and PHPUnit 7.0+.
- WP-CLI and its packages run on PHPUnit 7+, so legacy PHPUnit 4–6 polyfill support provided by v1 is no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported PHPUnit polyfills version range to use newer compatible releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->