### PR TITLE
Behat steps: support file names containing spaces

### DIFF
--- a/features/behat-steps.feature
+++ b/features/behat-steps.feature
@@ -44,6 +44,18 @@ Feature: Test that WP-CLI Behat steps work as expected
       Hello World
       """
 
+  Scenario: Test "Given a file" step with quoted path containing spaces
+    Given an empty directory
+    And a "test with spaces.txt" file:
+      """
+      Hello World with Spaces
+      """
+    Then the "test with spaces.txt" file should exist
+    And the "test with spaces.txt" file should contain:
+      """
+      Hello World with Spaces
+      """
+
   Scenario: Test "Given a cache file" step
     Given a WP installation
     And an empty cache
@@ -55,6 +67,19 @@ Feature: Test that WP-CLI Behat steps work as expected
     And the {SUITE_CACHE_DIR}/test-cache.txt file should contain:
       """
       Cached content
+      """
+
+  Scenario: Test "Given a cache file" step with quoted path containing spaces
+    Given a WP installation
+    And an empty cache
+    And a "test cache with spaces.txt" cache file:
+      """
+      Cached Content with Spaces
+      """
+    Then the "{SUITE_CACHE_DIR}/test cache with spaces.txt" file should exist
+    And the "{SUITE_CACHE_DIR}/test cache with spaces.txt" file should contain:
+      """
+      Cached Content with Spaces
       """
 
   Scenario: Test string replacement in file

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -120,14 +120,14 @@ trait GivenStepDefinitions {
 	 *
 	 * @access public
 	 *
-	 * @Given /^an? ([^\s]+) (file|cache file):$/
+	 * @Given /^an? ("[^"]+"|[^\s]+) (file|cache file):$/
 	 *
 	 * @param string $path
 	 * @param string $type
 	 * @param PyStringNode $content
 	 */
 	public function given_a_specific_file( $path, $type, PyStringNode $content ): void {
-		$path      = $this->replace_variables( (string) $path );
+		$path      = trim( $this->replace_variables( (string) $path ), '"' );
 		$content   = $this->replace_variables( (string) $content ) . "\n";
 		$full_path = 'cache file' === $type
 			? $this->variables['SUITE_CACHE_DIR'] . "/$path"

--- a/src/Context/ThenStepDefinitions.php
+++ b/src/Context/ThenStepDefinitions.php
@@ -458,7 +458,7 @@ trait ThenStepDefinitions {
 	 * @param string $expected Expected content.
 	 */
 	public function then_a_specific_file_folder_should_exist( $path, $type, $strictly, $action, $expected = null ): void {
-		$path = $this->replace_variables( $path );
+		$path = trim( $this->replace_variables( $path ), '"' );
 
 		// If it's a relative path, make it relative to the current test dir.
 		if ( ! Path::is_absolute( $path ) ) {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file and cache paths containing spaces or quotation marks.
  * File creation and existence checks now correctly resolve quoted paths and preserve exact file contents.
  * Added coverage for quoted filenames in both regular and cache directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->