### PR TITLE
Extract HTTP mocking template into a real PHP file

### DIFF
--- a/features/behat-steps.feature
+++ b/features/behat-steps.feature
@@ -389,6 +389,19 @@ Feature: Test that WP-CLI Behat steps work as expected
       """
     Then the wp-cli.yml file should exist
     And the mock-requests.php file should exist
+    And the mock-requests-data.php file should exist
+
+    When I run `php -l mock-requests.php`
+    Then STDOUT should contain:
+      """
+      No syntax errors detected
+      """
+
+    When I run `php -l mock-requests-data.php`
+    Then STDOUT should contain:
+      """
+      No syntax errors detected
+      """
 
   @require-wp
   Scenario: Test background process launch

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -98,4 +98,19 @@
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
 		<exclude-pattern>*/generate-coverage\.php$</exclude-pattern>
 	</rule>
+
+	<!-- These are stand-alone files that are copied into the test run directory and
+		 executed by the child WP-CLI process, not loaded as part of this package.
+		 They declare a class once per supported Requests major version, and their
+		 method signatures are dictated by the transport interface they implement,
+		 so unused parameters cannot be dropped. -->
+	<rule ref="Generic.Files.OneObjectStructurePerFile">
+		<exclude-pattern>*/src/Context/templates/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Classes.DuplicateClassName">
+		<exclude-pattern>*/src/Context/templates/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
+		<exclude-pattern>*/src/Context/templates/*</exclude-pattern>
+	</rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,9 @@ parameters:
     - tests
   excludePaths:
     - tests/data
+    # Templates are copied into the test run directory and executed by the
+    # child WP-CLI process, where Requests v1 classes may still exist.
+    - src/Context/templates
   scanDirectories:
     - vendor/wp-cli/wp-cli
     - vendor/phpunit/php-code-coverage

--- a/src/Context/GivenStepDefinitions.php
+++ b/src/Context/GivenStepDefinitions.php
@@ -191,6 +191,7 @@ trait GivenStepDefinitions {
 
 		$config_file = $this->variables['RUN_DIR'] . '/wp-cli.yml';
 		$mock_file   = $this->variables['RUN_DIR'] . '/mock-requests.php';
+		$data_file   = $this->variables['RUN_DIR'] . '/mock-requests-data.php';
 		$dir         = dirname( $config_file );
 
 		if ( ! file_exists( $dir ) ) {
@@ -209,146 +210,12 @@ FILE;
 
 		$this->mocked_requests[ $url_or_pattern ] = (string) $content;
 
-		$mocked_requests = var_export( $this->mocked_requests, true /* return */ );
-
-		$mock_file_contents = <<<FILE
-<?php
-/**
- * HTTP request mocking supporting both Requests v1 and v2.
- */
-
-trait WP_CLI_Tests_Mock_Requests_Trait {
-	public function request( \$url, \$headers = array(), \$data = array(), \$options = array() ) {
-		\$mocked_requests = $mocked_requests;
-
-		foreach ( \$mocked_requests as \$pattern => \$response ) {
-			\$pattern = '/' . preg_quote( \$pattern, '/' ) . '/';
-			if ( 1 === preg_match( \$pattern, \$url ) ) {
-				\$pos = strpos( \$response, "\\n\\n");
-				if ( false !== \$pos ) {
-					\$response = substr( \$response, 0, \$pos ) . "\\r\\n\\r\\n" . substr( \$response, \$pos + 2 );
-				}
-				if ( ! empty( \$options['filename'] ) ) {
-					\$body = '';
-					\$body_pos = strpos( \$response, "\\r\\n\\r\\n" );
-					if ( false !== \$body_pos ) {
-						\$body = substr( \$response, \$body_pos + 4 );
-					}
-					file_put_contents( \$options['filename'], \$body );
-				}
-				return \$response;
-			}
-		}
-
-		if ( class_exists( '\WpOrg\Requests\Transport\Curl' ) ) {
-			return ( new \WpOrg\Requests\Transport\Curl() )->request( \$url, \$headers, \$data, \$options );
-		}
-
-		return ( new \Requests_Transport_cURL() )->request( \$url, \$headers, \$data, \$options );
-	}
-
-	public function request_multiple( \$requests, \$options ) {
-		throw new Exception( 'Method not implemented: ' . __METHOD__ );
-	}
-
-	public static function test( \$capabilities = array() ) {
-		return true;
-	}
-}
-
-if ( interface_exists( '\WpOrg\Requests\Transport' ) ) {
-	class WP_CLI_Tests_Mock_Requests_Transport implements \WpOrg\Requests\Transport {
-		use WP_CLI_Tests_Mock_Requests_Trait;
-	}
-} else {
-	class WP_CLI_Tests_Mock_Requests_Transport implements \Requests_Transport {
-		use WP_CLI_Tests_Mock_Requests_Trait;
-	}
-}
-
-WP_CLI::add_hook(
-	'http_request_options',
-	static function( \$options ) {
-		\$options['transport'] = new WP_CLI_Tests_Mock_Requests_Transport();
-		return \$options;
-	}
-);
-
-WP_CLI::add_wp_hook(
-	'pre_http_request',
-	static function( \$pre, \$parsed_args, \$url ) {
-		\$mocked_requests = $mocked_requests;
-
-		foreach ( \$mocked_requests as \$pattern => \$response ) {
-			\$pattern = '/' . preg_quote( \$pattern, '/' ) . '/';
-			if ( 1 === preg_match( \$pattern, \$url ) ) {
-				\$pos = strpos( \$response, "\n\n");
-				if ( false !== \$pos ) {
-					\$response = substr( \$response, 0, \$pos ) . "\r\n\r\n" . substr( \$response, \$pos + 2 );
-				}
-
-				if ( class_exists( '\WpOrg\Requests\Requests' ) ) {
-					WpOrg\Requests\Requests::parse_multiple(
-						\$response,
-						array(
-							'url'     => \$url,
-							'headers' => array(),
-							'data'    => array(),
-							'options' => array_merge(
-								WpOrg\Requests\Requests::OPTION_DEFAULTS,
-								array(
-									'hooks' => new WpOrg\Requests\Hooks(),
-								)
-							),
-						)
-					);
-				} else {
-					\Requests::parse_multiple(
-						\$response,
-						array(
-							'url'     => \$url,
-							'headers' => array(),
-							'data'    => array(),
-							'options' => array(
-								'blocking'         => true,
-								'filename'         => false,
-								'follow_redirects' => true,
-								'redirected'       => 0,
-								'redirects'        => 10,
-								'hooks'            => new Requests_Hooks(),
-							),
-						)
-					);
-				}
-
-				if ( ! empty( \$parsed_args['filename'] ) ) {
-					file_put_contents( \$parsed_args['filename'], \$response->body );
-				}
-
-				return array(
-					'headers'  => \$response->headers->getAll(),
-					'body'     => \$response->body,
-					'response' => array(
-						'code'    => \$response->status_code,
-						'message' => get_status_header_desc( \$response->status_code ),
-					),
-					'cookies'  => array(),
-					'filename' => '',
-				);
-			}
-		}
-
-		return \$pre;
-	},
-	10,
-	3
-);
-FILE;
-
 		file_put_contents(
-			$mock_file,
-			$mock_file_contents
+			$data_file,
+			'<?php' . PHP_EOL . 'return ' . var_export( $this->mocked_requests, true /* return */ ) . ';' . PHP_EOL
 		);
+
+		copy( __DIR__ . '/templates/mock-requests.php', $mock_file );
 	}
 
 	/**

--- a/src/Context/templates/mock-requests.php
+++ b/src/Context/templates/mock-requests.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * HTTP request mocking supporting both Requests v1 and v2.
+ *
+ * This file is copied verbatim into the test run directory by
+ * `WP_CLI\Tests\Context\GivenStepDefinitions::given_a_request_to_a_url_respond_with_file()`.
+ * The mocked responses themselves are generated next to it as `mock-requests-data.php`.
+ */
+
+trait WP_CLI_Tests_Mock_Requests_Trait {
+	public function request( $url, $headers = array(), $data = array(), $options = array() ) {
+		$mocked_requests = require __DIR__ . '/mock-requests-data.php';
+
+		foreach ( $mocked_requests as $pattern => $response ) {
+			$pattern = '/' . preg_quote( $pattern, '/' ) . '/';
+			if ( 1 === preg_match( $pattern, $url ) ) {
+				$pos = strpos( $response, "\n\n" );
+				if ( false !== $pos ) {
+					$response = substr( $response, 0, $pos ) . "\r\n\r\n" . substr( $response, $pos + 2 );
+				}
+				if ( ! empty( $options['filename'] ) ) {
+					$body     = '';
+					$body_pos = strpos( $response, "\r\n\r\n" );
+					if ( false !== $body_pos ) {
+						$body = substr( $response, $body_pos + 4 );
+					}
+					file_put_contents( $options['filename'], $body );
+				}
+				return $response;
+			}
+		}
+
+		if ( class_exists( '\WpOrg\Requests\Transport\Curl' ) ) {
+			return ( new \WpOrg\Requests\Transport\Curl() )->request( $url, $headers, $data, $options );
+		}
+
+		return ( new \Requests_Transport_cURL() )->request( $url, $headers, $data, $options );
+	}
+
+	public function request_multiple( $requests, $options ) {
+		throw new Exception( 'Method not implemented: ' . __METHOD__ );
+	}
+
+	public static function test( $capabilities = array() ) {
+		return true;
+	}
+}
+
+if ( interface_exists( '\WpOrg\Requests\Transport' ) ) {
+	class WP_CLI_Tests_Mock_Requests_Transport implements \WpOrg\Requests\Transport {
+		use WP_CLI_Tests_Mock_Requests_Trait;
+	}
+} else {
+	class WP_CLI_Tests_Mock_Requests_Transport implements \Requests_Transport {
+		use WP_CLI_Tests_Mock_Requests_Trait;
+	}
+}
+
+WP_CLI::add_hook(
+	'http_request_options',
+	static function ( $options ) {
+		$options['transport'] = new WP_CLI_Tests_Mock_Requests_Transport();
+		return $options;
+	}
+);
+
+WP_CLI::add_wp_hook(
+	'pre_http_request',
+	static function ( $pre, $parsed_args, $url ) {
+		$mocked_requests = require __DIR__ . '/mock-requests-data.php';
+
+		foreach ( $mocked_requests as $pattern => $response ) {
+			$pattern = '/' . preg_quote( $pattern, '/' ) . '/';
+			if ( 1 === preg_match( $pattern, $url ) ) {
+				$pos = strpos( $response, "\n\n" );
+				if ( false !== $pos ) {
+					$response = substr( $response, 0, $pos ) . "\r\n\r\n" . substr( $response, $pos + 2 );
+				}
+
+				if ( class_exists( '\WpOrg\Requests\Requests' ) ) {
+					WpOrg\Requests\Requests::parse_multiple(
+						$response,
+						array(
+							'url'     => $url,
+							'headers' => array(),
+							'data'    => array(),
+							'options' => array_merge(
+								WpOrg\Requests\Requests::OPTION_DEFAULTS,
+								array(
+									'hooks' => new WpOrg\Requests\Hooks(),
+								)
+							),
+						)
+					);
+				} else {
+					\Requests::parse_multiple(
+						$response,
+						array(
+							'url'     => $url,
+							'headers' => array(),
+							'data'    => array(),
+							'options' => array(
+								'blocking'         => true,
+								'filename'         => false,
+								'follow_redirects' => true,
+								'redirected'       => 0,
+								'redirects'        => 10,
+								'hooks'            => new Requests_Hooks(),
+							),
+						)
+					);
+				}
+
+				if ( ! empty( $parsed_args['filename'] ) ) {
+					file_put_contents( $parsed_args['filename'], $response->body );
+				}
+
+				return array(
+					'headers'  => $response->headers->getAll(),
+					'body'     => $response->body,
+					'response' => array(
+						'code'    => $response->status_code,
+						'message' => get_status_header_desc( $response->status_code ),
+					),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			}
+		}
+
+		return $pre;
+	},
+	10,
+	3
+);


### PR DESCRIPTION
The mock transport used by `Given that HTTP requests to ... will respond
with:` lived in an interpolating heredoc, so none of the project's quality
gates could see it. `WP_CLI_CS` deliberately excludes `Generic.PHP.Syntax`
because "the parallel linter command takes care of linting" -- but the
linter only sees the string, not the PHP inside it, so a typo in the mock
transport passed `composer lint` and only surfaced as a confusing runtime
failure inside the child WP-CLI process.

The heredoc also silently interpreted its own escapes. `"\n\n"` in the
`pre_http_request` branch was rendered as two literal newlines inside the
generated source, and `"\r\n\r\n"` as literal CR/LF bytes, leaving control
characters embedded in string literals in the generated file. Any tooling
that normalized line endings on that file would have broken the header and
body split.

Move the template to `src/Context/templates/mock-requests.php` and copy it
verbatim, with the mocked responses written alongside it as a generated
`mock-requests-data.php` that the template requires. The template is now an
ordinary PHP file: it is highlighted by editors, picked up by the recursive
`parallel-lint` scan, and free of the 76 `\$` escapes. Emitting the response
data once instead of interpolating it into two places shrinks the step
definition from 166 lines to 33.

PHPStan excludes the template directory. It is executed by the child
process, where the Requests v1 classes it branches on may still exist, so
analyzing it against this package's dependency set only reports classes that
are absent here by design.

Behat now lints both generated files so the copied template and the
`var_export`ed data are checked at runtime too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RiuykJaAqpdnCLsn4Ewmm8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request mocking reliability across supported Requests versions.
  * Mocked responses now handle file output and WordPress HTTP response formatting more consistently.

* **Tests**
  * Added validation that generated mock files exist and pass PHP syntax checks.
  * Expanded coverage for HTTP response matching and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->