### PR TITLE
Make the test runners cheaper to run repeatedly and quieter to read back

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -1,0 +1,32 @@
+{
+  "file-name": [
+    "on",
+    {
+      "style": "kebab-case"
+    }
+  ],
+  "indentation": [
+    "on",
+    {
+      "Feature": 0,
+      "Background": 2,
+      "Scenario": 2,
+      "Examples": 4,
+      "Step": 4,
+      "given": 4,
+      "example": 6,
+      "and": 4
+    }
+  ],
+  "no-dupe-feature-names": "on",
+  "no-dupe-scenario-names": "off",
+  "no-empty-file": "on",
+  "no-files-without-scenarios": "on",
+  "no-multiple-empty-lines": "off",
+  "no-partially-commented-tag-lines": "on",
+  "no-trailing-spaces": "off",
+  "no-unnamed-features": "on",
+  "no-unnamed-scenarios": "on",
+  "no-scenario-outlines-without-examples": "on",
+  "use-and": "on"
+}

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -104,6 +104,39 @@ composer behat -- features/cli-info.feature
 
 Prepending with the double dash is needed because the arguments would otherwise be sent to Composer itself, not the tool that Composer executes.
 
+The same mechanism works for narrowing a run down further, or for bailing out early:
+```bash
+# A single scenario, identified by the line it starts on.
+composer behat -- features/cli-info.feature:12
+
+# Every scenario carrying a given tag.
+composer behat -- --tags=@require-wp-5.0
+
+# Stop at the first failing scenario instead of running the whole suite.
+composer behat -- --stop-on-failure
+
+# Re-run only the scenarios that failed the last time.
+composer behat-rerun
+```
+
+### Controlling the amount of output
+
+Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
+
+  - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
+  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+
+```bash
+NO_COLOR=1 WP_CLI_TEST_QUIET=1 composer phpstan
+```
+
+This is worth setting permanently in environments that read the output back rather than display it, such as an AI coding agent's shell:
+
+```bash
+export NO_COLOR=1
+export WP_CLI_TEST_QUIET=1
+```
+
 ### Controlling the test environment
 
 #### WordPress Version

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -90,6 +90,7 @@ You can use the following commands to control the tests:
 * `composer prepare-tests` - Set up the database that is needed for running the functional tests. This is only needed once.
 * `composer test` - Run all test suites.
 * `composer lint` - Run only the linting test suite.
+* `composer lint-gherkin` - Run only the Gherkin linter over the feature files.
 * `composer phpcs` - Run only the code sniffer test suite.
 * `composer phpcbf` - Run only the code sniffer cleanup.
 * `composer phpunit` - Run only the unit test suite.
@@ -119,12 +120,26 @@ composer behat -- --stop-on-failure
 composer behat-rerun
 ```
 
+### Linting the feature files
+
+`composer lint-gherkin` checks `features/` with
+[gherkin-lint-plus](https://www.npmjs.com/package/gherkin-lint-plus), against the
+`.gherkin-lintrc` ruleset shipped with this package. A project that needs
+different rules can override it by committing its own `.gherkin-lintrc`.
+
+The linter is a Node package, so it is run through `npx` and needs Node.js 20 or
+later. Where `npx` is not available the check reports that it is skipping, rather
+than failing a suite that is otherwise entirely PHP. Pin a different release of
+the linter with `WP_CLI_TEST_GHERKIN_LINT_VERSION`.
+
 ### Controlling the amount of output
 
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
   - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
   - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+
+`NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 
 ```bash
 NO_COLOR=1 WP_CLI_TEST_QUIET=1 composer phpstan

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -129,8 +129,8 @@ different rules can override it by committing its own `.gherkin-lintrc`.
 
 The linter is a Node package, so it is run through `npx` and needs Node.js 20 or
 later. Where `npx` is not available the check reports that it is skipping, rather
-than failing a suite that is otherwise entirely PHP. Pin a different release of
-the linter with `WP_CLI_TEST_GHERKIN_LINT_VERSION`.
+than failing a suite that is otherwise entirely PHP. Its version is pinned in
+this package's `package.json`, which exists only to hold that pin.
 
 ### Controlling the amount of output
 

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -152,6 +152,12 @@ Here's how to run your tests against the latest trunk version of WordPress:
 WP_VERSION=trunk composer behat
 ```
 
+Resolving `latest`, or a `X.Y` version without a patch number, needs a network
+request. The answer is cached in the system temp directory for a day, so that
+repeated runs do not repeat the lookup, and so that a run without connectivity
+falls back to the last known answer. `WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the
+lifetime of that cache in seconds; `0` looks the version up every time.
+
 #### WordPress Archive
 
 Instead of downloading WordPress from WordPress.org, you can run the tests against an arbitrary

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -208,8 +208,8 @@ this package's `package.json`, which exists only to hold that pin.
 
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
-  - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
+* `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) turns off the ANSI color codes in the output of every runner. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
+* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -261,7 +261,7 @@ this package's `package.json`, which exists only to hold that pin.
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
 * `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) turns off the ANSI color codes in the output of every runner. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
+* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. This covers the analysis of the PHP files themselves; the checks over the PHP blocks embedded in feature files keep their own reports, which are rewritten to point back at the feature file a block came from. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 

--- a/.readme-partials/USING.md
+++ b/.readme-partials/USING.md
@@ -11,12 +11,14 @@ To make use of the WP-CLI testing framework, you need to complete the following 
         "behat": "run-behat-tests",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
+        "lint-gherkin": "run-gherkin-lint-tests",
         "phpcs": "run-phpcs-tests",
         "phpcbf": "run-phpcbf-cleanup",
         "phpunit": "run-php-unit-tests",
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",
+            "@lint-gherkin",
             "@phpcs",
             "@phpunit",
             "@behat"
@@ -137,7 +139,7 @@ this package's `package.json`, which exists only to hold that pin.
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
   - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 
@@ -167,11 +169,12 @@ Here's how to run your tests against the latest trunk version of WordPress:
 WP_VERSION=trunk composer behat
 ```
 
-Resolving `latest`, or a `X.Y` version without a patch number, needs a network
-request. The answer is cached in the system temp directory for a day, so that
-repeated runs do not repeat the lookup, and so that a run without connectivity
-falls back to the last known answer. `WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the
-lifetime of that cache in seconds; `0` looks the version up every time.
+Resolving `latest`, or a `X.Y` version without a patch number, needs the
+WordPress versions data, which is fetched once and cached in the system temp
+directory for a day. Repeated runs do not repeat the request, and a run without
+connectivity falls back to the last known copy.
+`WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the lifetime of that cache in seconds;
+`0` fetches it every time.
 
 #### WordPress Archive
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Here's how to run your tests against the latest trunk version of WordPress:
 WP_VERSION=trunk composer behat
 ```
 
+Resolving `latest`, or a `X.Y` version without a patch number, needs a network
+request. The answer is cached in the system temp directory for a day, so that
+repeated runs do not repeat the lookup, and so that a run without connectivity
+falls back to the last known answer. `WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the
+lifetime of that cache in seconds; `0` looks the version up every time.
+
 #### WordPress Archive
 
 Instead of downloading WordPress from WordPress.org, you can run the tests against an arbitrary

--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ To make use of the WP-CLI testing framework, you need to complete the following 
         "behat": "run-behat-tests",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
+        "lint-gherkin": "run-gherkin-lint-tests",
         "phpcs": "run-phpcs-tests",
         "phpcbf": "run-phpcbf-cleanup",
         "phpunit": "run-php-unit-tests",
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",
+            "@lint-gherkin",
             "@phpcs",
             "@phpunit",
             "@behat"
@@ -148,7 +150,7 @@ this package's `package.json`, which exists only to hold that pin.
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
   - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 
@@ -178,11 +180,12 @@ Here's how to run your tests against the latest trunk version of WordPress:
 WP_VERSION=trunk composer behat
 ```
 
-Resolving `latest`, or a `X.Y` version without a patch number, needs a network
-request. The answer is cached in the system temp directory for a day, so that
-repeated runs do not repeat the lookup, and so that a run without connectivity
-falls back to the last known answer. `WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the
-lifetime of that cache in seconds; `0` looks the version up every time.
+Resolving `latest`, or a `X.Y` version without a patch number, needs the
+WordPress versions data, which is fetched once and cached in the system temp
+directory for a day. Repeated runs do not repeat the request, and a run without
+connectivity falls back to the last known copy.
+`WP_CLI_TEST_WP_VERSION_CACHE_TTL` sets the lifetime of that cache in seconds;
+`0` fetches it every time.
 
 #### WordPress Archive
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ different rules can override it by committing its own `.gherkin-lintrc`.
 
 The linter is a Node package, so it is run through `npx` and needs Node.js 20 or
 later. Where `npx` is not available the check reports that it is skipping, rather
-than failing a suite that is otherwise entirely PHP. Pin a different release of
-the linter with `WP_CLI_TEST_GHERKIN_LINT_VERSION`.
+than failing a suite that is otherwise entirely PHP. Its version is pinned in
+this package's `package.json`, which exists only to hold that pin.
 
 ### Controlling the amount of output
 

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ this package's `package.json`, which exists only to hold that pin.
 
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
-  - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
+* `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) turns off the ANSI color codes in the output of every runner. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
+* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can use the following commands to control the tests:
 * `composer prepare-tests` - Set up the database that is needed for running the functional tests. This is only needed once.
 * `composer test` - Run all test suites.
 * `composer lint` - Run only the linting test suite.
+* `composer lint-gherkin` - Run only the Gherkin linter over the feature files.
 * `composer phpcs` - Run only the code sniffer test suite.
 * `composer phpcbf` - Run only the code sniffer cleanup.
 * `composer phpunit` - Run only the unit test suite.
@@ -130,12 +131,26 @@ composer behat -- --stop-on-failure
 composer behat-rerun
 ```
 
+### Linting the feature files
+
+`composer lint-gherkin` checks `features/` with
+[gherkin-lint-plus](https://www.npmjs.com/package/gherkin-lint-plus), against the
+`.gherkin-lintrc` ruleset shipped with this package. A project that needs
+different rules can override it by committing its own `.gherkin-lintrc`.
+
+The linter is a Node package, so it is run through `npx` and needs Node.js 20 or
+later. Where `npx` is not available the check reports that it is skipping, rather
+than failing a suite that is otherwise entirely PHP. Pin a different release of
+the linter with `WP_CLI_TEST_GHERKIN_LINT_VERSION`.
+
 ### Controlling the amount of output
 
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
   - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
   - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+
+`NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 
 ```bash
 NO_COLOR=1 WP_CLI_TEST_QUIET=1 composer phpstan

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ this package's `package.json`, which exists only to hold that pin.
 Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
 
 * `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) turns off the ANSI color codes in the output of every runner. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
-* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. Behat's own output is already minimal, so it is unaffected.
+* `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table. This covers the analysis of the PHP files themselves; the checks over the PHP blocks embedded in feature files keep their own reports, which are rewritten to point back at the feature file a block came from. Behat's own output is already minimal, so it is unaffected.
 
 `NO_COLOR` also covers the Gherkin linter, which colors its report unconditionally and has no plain output format of its own.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,39 @@ composer behat -- features/cli-info.feature
 
 Prepending with the double dash is needed because the arguments would otherwise be sent to Composer itself, not the tool that Composer executes.
 
+The same mechanism works for narrowing a run down further, or for bailing out early:
+```bash
+# A single scenario, identified by the line it starts on.
+composer behat -- features/cli-info.feature:12
+
+# Every scenario carrying a given tag.
+composer behat -- --tags=@require-wp-5.0
+
+# Stop at the first failing scenario instead of running the whole suite.
+composer behat -- --stop-on-failure
+
+# Re-run only the scenarios that failed the last time.
+composer behat-rerun
+```
+
+### Controlling the amount of output
+
+Two environment variables make the test tools less chatty. Both are unset by default, which leaves the output exactly as it has always been.
+
+  - `NO_COLOR` (the [no-color.org](https://no-color.org/) convention) stops the runners from forcing ANSI color codes on, and leaves the decision to each tool's own terminal detection. Set this when capturing output to a file or a pipe, where the escape sequences are noise.
+  - `WP_CLI_TEST_QUIET` switches the reporters to their most compact form: PHP_CodeSniffer reports one `file:line:col` line per violation with no progress ticker, PHPStan reports one `file:line:message` line per error with no progress bar and no result table, and Behat stops printing step definition snippets for undefined steps.
+
+```bash
+NO_COLOR=1 WP_CLI_TEST_QUIET=1 composer phpstan
+```
+
+This is worth setting permanently in environments that read the output back rather than display it, such as an AI coding agent's shell:
+
+```bash
+export NO_COLOR=1
+export WP_CLI_TEST_QUIET=1
+```
+
 ### Controlling the test environment
 
 #### WordPress Version

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -108,13 +108,11 @@ WP_VERSIONS_URL="https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts
 WP_VERSIONS_CACHE_FILE="${TMPDIR:-/tmp}/wp-cli-test-wp-version-cache/wp-versions.json"
 WP_VERSIONS_CACHE_TTL="${WP_CLI_TEST_WP_VERSION_CACHE_TTL:-86400}"
 
-# A typo must not turn into a cache that never expires: the age comparison below
-# errors out on a non-numeric TTL, which would then accept the cached copy at
-# any age.
-if ! is_numeric "${WP_VERSIONS_CACHE_TTL}"; then
-	echo "Warning: WP_CLI_TEST_WP_VERSION_CACHE_TTL is not a number of seconds, falling back to 86400."
-	WP_VERSIONS_CACHE_TTL=86400
-fi
+# The versions data is a non-empty object mapping every release to its status.
+# An error page, or a copy that was truncated on its way to disk, is not one.
+is_valid_versions_json() {
+	jq -e 'type == "object" and length > 0' > /dev/null 2>&1
+}
 
 # Print the cached versions file if it is younger than the given number of
 # seconds. A negative TTL accepts it at any age.
@@ -133,6 +131,11 @@ read_versions_cache() {
 		esac
 		[ "${age}" -lt "${ttl}" ] || return 1
 	fi
+
+	# Held to the same standard as a fetched copy, so that an unusable cache
+	# counts as a miss and the network gets a chance to replace it, instead of
+	# being served unchecked for the rest of its lifetime.
+	is_valid_versions_json < "${WP_VERSIONS_CACHE_FILE}" || return 1
 
 	cat "${WP_VERSIONS_CACHE_FILE}"
 }
@@ -167,8 +170,17 @@ write_versions_cache() {
 # to STDERR so that they cannot end up inside the returned JSON.
 get_wp_versions() {
 	local json
+	local ttl="${WP_VERSIONS_CACHE_TTL}"
 
-	json=$( read_versions_cache "${WP_VERSIONS_CACHE_TTL}" )
+	# A typo must not turn into a cache that never expires: the age comparison
+	# errors out on a non-numeric TTL, which would then accept the cached copy
+	# at any age.
+	if ! is_numeric "${ttl}"; then
+		echo "Warning: WP_CLI_TEST_WP_VERSION_CACHE_TTL is not a number of seconds, falling back to 86400." >&2
+		ttl=86400
+	fi
+
+	json=$( read_versions_cache "${ttl}" )
 	if [ -n "${json}" ]; then
 		printf '%s' "${json}"
 		return 0
@@ -179,7 +191,7 @@ get_wp_versions() {
 	json=$( curl -s --connect-timeout 10 --max-time 30 "${WP_VERSIONS_URL}" )
 
 	# Only cache a well-formed response; an error page is not one.
-	if echo "${json}" | jq -e 'type == "object" and length > 0' > /dev/null 2>&1; then
+	if printf '%s' "${json}" | is_valid_versions_json; then
 		write_versions_cache "${json}"
 		printf '%s' "${json}"
 		return 0
@@ -201,7 +213,7 @@ if [ "${WP_VERSION-latest}" = "latest" ]; then
 	WP_VERSION=$( get_wp_versions | jq -r 'to_entries | map( select( .value == "latest" ) ) | last | .key // empty' )
 
 	if [ -z "${WP_VERSION}" ]; then
-		echo "Warning: Could not determine the latest WordPress version. Version-specific tags will not be filtered."
+		echo "Warning: Could not determine the latest WordPress version. Version-specific tags will not be filtered." >&2
 	fi
 
 	export WP_VERSION

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -97,9 +97,64 @@ if [ -n "${WP_CLI_TEST_CORE_ZIP-}" ] && [ -z "${WP_VERSION-}" ]; then
 	export WP_VERSION=trunk
 fi
 
+# Resolving WP_VERSION costs up to two network round trips on every invocation.
+# Cache the answers, so that re-running a single scenario while iterating does
+# not repeat them, and so that a run without connectivity can fall back to the
+# last known answer instead of ending up with no version at all.
+#
+# Set WP_CLI_TEST_WP_VERSION_CACHE_TTL to 0 to always refetch.
+WP_VERSION_CACHE_DIR="${TMPDIR:-/tmp}/wp-cli-test-wp-version-cache"
+WP_VERSION_CACHE_TTL="${WP_CLI_TEST_WP_VERSION_CACHE_TTL:-86400}"
+
+# Print a cache entry if it exists and is younger than the given number of
+# seconds. A negative TTL accepts an entry of any age.
+read_version_cache() {
+	local cache_file="${WP_VERSION_CACHE_DIR}/$1"
+	local ttl="$2"
+	local age
+
+	[ -s "${cache_file}" ] || return 1
+
+	if [ "${ttl}" -ge 0 ]; then
+		# PHP rather than `find -newermt`, which is not portable across
+		# GNU and BSD userlands. The Behat runner needs PHP anyway.
+		age=$(php -r 'echo time() - filemtime( $argv[1] );' "${cache_file}" 2>/dev/null)
+		case ${age} in
+			''|*[!0-9]*) return 1;;
+		esac
+		[ "${age}" -lt "${ttl}" ] || return 1
+	fi
+
+	cat "${cache_file}"
+}
+
+write_version_cache() {
+	mkdir -p "${WP_VERSION_CACHE_DIR}" 2>/dev/null || return 0
+	printf '%s' "$2" > "${WP_VERSION_CACHE_DIR}/$1" 2>/dev/null || true
+}
+
 # Turn WP_VERSION into an actual number to make sure our tags work correctly.
 if [ "${WP_VERSION-latest}" = "latest" ]; then
-	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
+	LATEST_WP_VERSION=$(read_version_cache latest "${WP_VERSION_CACHE_TTL}")
+
+	if [ -z "${LATEST_WP_VERSION}" ]; then
+		LATEST_WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current // empty")
+
+		if [ -n "${LATEST_WP_VERSION}" ]; then
+			write_version_cache latest "${LATEST_WP_VERSION}"
+		else
+			# Prefer a stale answer over no answer.
+			LATEST_WP_VERSION=$(read_version_cache latest -1)
+
+			if [ -n "${LATEST_WP_VERSION}" ]; then
+				echo "Warning: Could not reach api.wordpress.org, falling back to the cached latest WordPress version ${LATEST_WP_VERSION}."
+			else
+				echo "Warning: Could not determine the latest WordPress version. Version-specific tags will not be filtered."
+			fi
+		fi
+	fi
+
+	export WP_VERSION="${LATEST_WP_VERSION}"
 fi
 
 # Normalize WP_VERSION=X.Y.0 to X.Y (WordPress uses X.Y for the initial release, not X.Y.0).
@@ -107,7 +162,19 @@ fi
 if [[ "${WP_VERSION}" =~ ^([0-9]+\.[0-9]+)\.0$ ]]; then
 	export WP_VERSION="${BASH_REMATCH[1]}"
 elif [[ "${WP_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-	WP_VERSIONS_JSON=$(curl -s https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts/wp-versions.json)
+	WP_VERSIONS_JSON=$(read_version_cache wp-versions.json "${WP_VERSION_CACHE_TTL}")
+
+	if [ -z "${WP_VERSIONS_JSON}" ]; then
+		WP_VERSIONS_JSON=$(curl -s https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts/wp-versions.json)
+
+		# Only cache a well-formed response; a proxy error page is not one.
+		if echo "${WP_VERSIONS_JSON}" | jq -e 'type == "object"' > /dev/null 2>&1; then
+			write_version_cache wp-versions.json "${WP_VERSIONS_JSON}"
+		else
+			WP_VERSIONS_JSON=$(read_version_cache wp-versions.json -1)
+		fi
+	fi
+
 	if [ -n "${WP_VERSIONS_JSON}" ]; then
 		RESOLVED_VERSION=$(echo "${WP_VERSIONS_JSON}" | jq -r --arg prefix "${WP_VERSION}." 'keys | map(select(startswith($prefix))) | sort_by(split(".") | map(tonumber)) | last // empty')
 		if [ -n "${RESOLVED_VERSION}" ]; then

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -141,6 +141,19 @@ if [[ "${WP_CLI_TEST_COVERAGE}" == "true" ]] && vendor/bin/behat --help 2>/dev/n
 	BEHAT_EXTRA_ARGS+=('--xdebug')
 fi
 
+# Honor the NO_COLOR convention (https://no-color.org/).
+if [ -n "${NO_COLOR}" ]; then
+	BEHAT_EXTRA_ARGS+=('--no-colors')
+fi
+
+# Drop the step definition snippets that Behat prints for undefined steps. They
+# are long, and they are only actionable when you are writing new step
+# definitions in this package. Useful for CI logs and for AI coding agents,
+# which pay for every token of the report they read back.
+if [ -n "${WP_CLI_TEST_QUIET}" ]; then
+	BEHAT_EXTRA_ARGS+=('--no-snippets')
+fi
+
 # Run the functional tests.
 FORMAT_ARGS=(--format progress)
 for arg in "$@"; do

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -97,89 +97,90 @@ if [ -n "${WP_CLI_TEST_CORE_ZIP-}" ] && [ -z "${WP_VERSION-}" ]; then
 	export WP_VERSION=trunk
 fi
 
-# Resolving WP_VERSION costs up to two network round trips on every invocation.
-# Cache the answers, so that re-running a single scenario while iterating does
-# not repeat them, and so that a run without connectivity can fall back to the
-# last known answer instead of ending up with no version at all.
+# Everything WP_VERSION resolution needs is in one file: the wp-versions artifact
+# maps every WordPress release to its status, with the current one marked
+# "latest". Cache it, so that re-running a single scenario while iterating does
+# not refetch it every time, and so that a run without connectivity can fall back
+# to the last known answer instead of ending up with no version at all.
 #
 # Set WP_CLI_TEST_WP_VERSION_CACHE_TTL to 0 to always refetch.
-WP_VERSION_CACHE_DIR="${TMPDIR:-/tmp}/wp-cli-test-wp-version-cache"
-WP_VERSION_CACHE_TTL="${WP_CLI_TEST_WP_VERSION_CACHE_TTL:-86400}"
+WP_VERSIONS_URL="https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts/wp-versions.json"
+WP_VERSIONS_CACHE_FILE="${TMPDIR:-/tmp}/wp-cli-test-wp-version-cache/wp-versions.json"
+WP_VERSIONS_CACHE_TTL="${WP_CLI_TEST_WP_VERSION_CACHE_TTL:-86400}"
 
-# Print a cache entry if it exists and is younger than the given number of
-# seconds. A negative TTL accepts an entry of any age.
-read_version_cache() {
-	local cache_file="${WP_VERSION_CACHE_DIR}/$1"
-	local ttl="$2"
+# Print the cached versions file if it is younger than the given number of
+# seconds. A negative TTL accepts it at any age.
+read_versions_cache() {
+	local ttl="$1"
 	local age
 
-	[ -s "${cache_file}" ] || return 1
+	[ -s "${WP_VERSIONS_CACHE_FILE}" ] || return 1
 
 	if [ "${ttl}" -ge 0 ]; then
 		# PHP rather than `find -newermt`, which is not portable across
 		# GNU and BSD userlands. The Behat runner needs PHP anyway.
-		age=$(php -r 'echo time() - filemtime( $argv[1] );' "${cache_file}" 2>/dev/null)
+		age=$(php -r 'echo time() - filemtime( $argv[1] );' "${WP_VERSIONS_CACHE_FILE}" 2>/dev/null)
 		case ${age} in
 			''|*[!0-9]*) return 1;;
 		esac
 		[ "${age}" -lt "${ttl}" ] || return 1
 	fi
 
-	cat "${cache_file}"
+	cat "${WP_VERSIONS_CACHE_FILE}"
 }
 
-write_version_cache() {
-	mkdir -p "${WP_VERSION_CACHE_DIR}" 2>/dev/null || return 0
-	printf '%s' "$2" > "${WP_VERSION_CACHE_DIR}/$1" 2>/dev/null || true
+# Print the WordPress versions data, from the cache where possible. Warnings go
+# to STDERR so that they cannot end up inside the returned JSON.
+get_wp_versions() {
+	local json
+
+	json=$( read_versions_cache "${WP_VERSIONS_CACHE_TTL}" )
+	if [ -n "${json}" ]; then
+		printf '%s' "${json}"
+		return 0
+	fi
+
+	json=$( curl -s "${WP_VERSIONS_URL}" )
+
+	# Only cache a well-formed response; an error page is not one.
+	if echo "${json}" | jq -e 'type == "object" and length > 0' > /dev/null 2>&1; then
+		mkdir -p "$( dirname "${WP_VERSIONS_CACHE_FILE}" )" 2>/dev/null \
+			&& printf '%s' "${json}" > "${WP_VERSIONS_CACHE_FILE}" 2>/dev/null || true
+		printf '%s' "${json}"
+		return 0
+	fi
+
+	# Prefer a stale answer over no answer.
+	json=$( read_versions_cache -1 )
+	if [ -n "${json}" ]; then
+		echo "Warning: Could not fetch the WordPress versions data, falling back to the cached copy." >&2
+		printf '%s' "${json}"
+		return 0
+	fi
+
+	return 1
 }
 
 # Turn WP_VERSION into an actual number to make sure our tags work correctly.
 if [ "${WP_VERSION-latest}" = "latest" ]; then
-	LATEST_WP_VERSION=$(read_version_cache latest "${WP_VERSION_CACHE_TTL}")
+	WP_VERSION=$( get_wp_versions | jq -r 'to_entries | map( select( .value == "latest" ) ) | last | .key // empty' )
 
-	if [ -z "${LATEST_WP_VERSION}" ]; then
-		LATEST_WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current // empty")
-
-		if [ -n "${LATEST_WP_VERSION}" ]; then
-			write_version_cache latest "${LATEST_WP_VERSION}"
-		else
-			# Prefer a stale answer over no answer.
-			LATEST_WP_VERSION=$(read_version_cache latest -1)
-
-			if [ -n "${LATEST_WP_VERSION}" ]; then
-				echo "Warning: Could not reach api.wordpress.org, falling back to the cached latest WordPress version ${LATEST_WP_VERSION}."
-			else
-				echo "Warning: Could not determine the latest WordPress version. Version-specific tags will not be filtered."
-			fi
-		fi
+	if [ -z "${WP_VERSION}" ]; then
+		echo "Warning: Could not determine the latest WordPress version. Version-specific tags will not be filtered."
 	fi
 
-	export WP_VERSION="${LATEST_WP_VERSION}"
-fi
-
-# Normalize WP_VERSION=X.Y.0 to X.Y (WordPress uses X.Y for the initial release, not X.Y.0).
-# If WP_VERSION=X.Y (major.minor only), resolve to the latest available patch release.
-if [[ "${WP_VERSION}" =~ ^([0-9]+\.[0-9]+)\.0$ ]]; then
+	export WP_VERSION
+# Normalize WP_VERSION=X.Y.0 to X.Y (WordPress uses X.Y for the initial release,
+# not X.Y.0). This asks for that specific release, so it must not fall through to
+# the patch resolution below.
+elif [[ "${WP_VERSION}" =~ ^([0-9]+\.[0-9]+)\.0$ ]]; then
 	export WP_VERSION="${BASH_REMATCH[1]}"
+# If WP_VERSION=X.Y (major.minor only), resolve to the latest available patch release.
 elif [[ "${WP_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-	WP_VERSIONS_JSON=$(read_version_cache wp-versions.json "${WP_VERSION_CACHE_TTL}")
+	RESOLVED_VERSION=$( get_wp_versions | jq -r --arg prefix "${WP_VERSION}." 'keys | map( select( startswith( $prefix ) ) ) | sort_by( split(".") | map( tonumber ) ) | last // empty' )
 
-	if [ -z "${WP_VERSIONS_JSON}" ]; then
-		WP_VERSIONS_JSON=$(curl -s https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts/wp-versions.json)
-
-		# Only cache a well-formed response; a proxy error page is not one.
-		if echo "${WP_VERSIONS_JSON}" | jq -e 'type == "object"' > /dev/null 2>&1; then
-			write_version_cache wp-versions.json "${WP_VERSIONS_JSON}"
-		else
-			WP_VERSIONS_JSON=$(read_version_cache wp-versions.json -1)
-		fi
-	fi
-
-	if [ -n "${WP_VERSIONS_JSON}" ]; then
-		RESOLVED_VERSION=$(echo "${WP_VERSIONS_JSON}" | jq -r --arg prefix "${WP_VERSION}." 'keys | map(select(startswith($prefix))) | sort_by(split(".") | map(tonumber)) | last // empty')
-		if [ -n "${RESOLVED_VERSION}" ]; then
-			export WP_VERSION="${RESOLVED_VERSION}"
-		fi
+	if [ -n "${RESOLVED_VERSION}" ]; then
+		export WP_VERSION="${RESOLVED_VERSION}"
 	fi
 fi
 
@@ -211,14 +212,6 @@ fi
 # Honor the NO_COLOR convention (https://no-color.org/).
 if [ -n "${NO_COLOR}" ]; then
 	BEHAT_EXTRA_ARGS+=('--no-colors')
-fi
-
-# Drop the step definition snippets that Behat prints for undefined steps. They
-# are long, and they are only actionable when you are writing new step
-# definitions in this package. Useful for CI logs and for AI coding agents,
-# which pay for every token of the report they read back.
-if [ -n "${WP_CLI_TEST_QUIET}" ]; then
-	BEHAT_EXTRA_ARGS+=('--no-snippets')
 fi
 
 # Run the functional tests.

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -108,6 +108,14 @@ WP_VERSIONS_URL="https://raw.githubusercontent.com/wp-cli/wp-cli-tests/artifacts
 WP_VERSIONS_CACHE_FILE="${TMPDIR:-/tmp}/wp-cli-test-wp-version-cache/wp-versions.json"
 WP_VERSIONS_CACHE_TTL="${WP_CLI_TEST_WP_VERSION_CACHE_TTL:-86400}"
 
+# A typo must not turn into a cache that never expires: the age comparison below
+# errors out on a non-numeric TTL, which would then accept the cached copy at
+# any age.
+if ! is_numeric "${WP_VERSIONS_CACHE_TTL}"; then
+	echo "Warning: WP_CLI_TEST_WP_VERSION_CACHE_TTL is not a number of seconds, falling back to 86400."
+	WP_VERSIONS_CACHE_TTL=86400
+fi
+
 # Print the cached versions file if it is younger than the given number of
 # seconds. A negative TTL accepts it at any age.
 read_versions_cache() {
@@ -129,6 +137,32 @@ read_versions_cache() {
 	cat "${WP_VERSIONS_CACHE_FILE}"
 }
 
+# Store the versions data for the next run. The write goes through a temporary
+# file in the same directory, so that a concurrent runner reading the cache sees
+# either the previous copy or the new one, never a partial write. Caching is
+# best effort throughout: a temp directory that cannot be written to is not a
+# reason to fail the run.
+write_versions_cache() {
+	local dir
+	local tmp
+
+	dir=$( dirname "${WP_VERSIONS_CACHE_FILE}" )
+	mkdir -p "${dir}" 2>/dev/null || return 0
+
+	tmp=$( mktemp "${dir}/wp-versions.XXXXXX" 2>/dev/null ) || return 0
+
+	if printf '%s' "$1" > "${tmp}" 2>/dev/null; then
+		# mktemp creates the file private to its owner; the cache directory is
+		# shared, and the data in it is public.
+		chmod 644 "${tmp}" 2>/dev/null
+		mv -f "${tmp}" "${WP_VERSIONS_CACHE_FILE}" 2>/dev/null || rm -f "${tmp}"
+	else
+		rm -f "${tmp}"
+	fi
+
+	return 0
+}
+
 # Print the WordPress versions data, from the cache where possible. Warnings go
 # to STDERR so that they cannot end up inside the returned JSON.
 get_wp_versions() {
@@ -140,12 +174,13 @@ get_wp_versions() {
 		return 0
 	fi
 
-	json=$( curl -s "${WP_VERSIONS_URL}" )
+	# Bounded, so that an unreachable or unresponsive host falls back to the
+	# cached copy instead of holding up the run indefinitely.
+	json=$( curl -s --connect-timeout 10 --max-time 30 "${WP_VERSIONS_URL}" )
 
 	# Only cache a well-formed response; an error page is not one.
 	if echo "${json}" | jq -e 'type == "object" and length > 0' > /dev/null 2>&1; then
-		mkdir -p "$( dirname "${WP_VERSIONS_CACHE_FILE}" )" 2>/dev/null \
-			&& printf '%s' "${json}" > "${WP_VERSIONS_CACHE_FILE}" 2>/dev/null || true
+		write_versions_cache "${json}"
 		printf '%s' "${json}"
 		return 0
 	fi

--- a/bin/run-gherkin-lint-tests
+++ b/bin/run-gherkin-lint-tests
@@ -42,9 +42,17 @@ then
 	CONFIG_FILE="${WP_CLI_TESTS_ROOT}/.gherkin-lintrc"
 fi
 
-# Pinned so that a new release of the linter cannot turn a green build red
-# without a commit in this repository.
-GHERKIN_LINT_VERSION="${WP_CLI_TEST_GHERKIN_LINT_VERSION:-1.0.2}"
+# The linter is pinned so that one of its releases cannot turn a green build red
+# without a commit here. The pin lives in package.json rather than in this file,
+# because a version string inside a shell script is invisible to Dependabot.
+PACKAGE_JSON="${WP_CLI_TESTS_ROOT}/package.json"
+GHERKIN_LINT_VERSION=$( php -r '$package = json_decode( (string) file_get_contents( $argv[1] ), true ); echo isset( $package["devDependencies"]["gherkin-lint-plus"] ) ? $package["devDependencies"]["gherkin-lint-plus"] : "";' "${PACKAGE_JSON}" 2> /dev/null )
+
+if [ -z "${GHERKIN_LINT_VERSION}" ]
+then
+	echo "Could not read the pinned gherkin-lint-plus version from ${PACKAGE_JSON}."
+	exit 1;
+fi
 
 # Without an explicit path the linter walks the whole working directory, vendor
 # included. The feature files are the target.

--- a/bin/run-gherkin-lint-tests
+++ b/bin/run-gherkin-lint-tests
@@ -72,7 +72,14 @@ then
 	# It writes the report to STDERR, so strip the escape sequences from that
 	# stream while leaving STDOUT and the exit code alone.
 	STDERR_FILE=$( mktemp )
-	trap 'rm -f "${STDERR_FILE}"' EXIT HUP INT TERM
+	trap 'rm -f "${STDERR_FILE}"' EXIT
+
+	# A signal handler resumes where it left off, so stopping here is what keeps
+	# the report below from being read back out of the file the handler has just
+	# removed. 128+n is the status a shell reports for a death by signal n.
+	trap 'rm -f "${STDERR_FILE}"; exit 129' HUP
+	trap 'rm -f "${STDERR_FILE}"; exit 130' INT
+	trap 'rm -f "${STDERR_FILE}"; exit 143' TERM
 
 	run_linter "$@" 2> "${STDERR_FILE}"
 	STATUS=$?

--- a/bin/run-gherkin-lint-tests
+++ b/bin/run-gherkin-lint-tests
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# Run the Gherkin linter only if there are feature files to lint.
+if [ ! -d "features" ]
+then
+	exit 0;
+fi
+
+# The linter is a Node package, which a PHP project cannot assume is present.
+# Skip rather than fail, the same way the Behat runner skips a package without a
+# behat.yml. The check still runs in CI, where Node is always available.
+if ! command -v npx > /dev/null 2>&1
+then
+	echo 'Did not detect the "npx" command, skipping the Gherkin linting.'
+	echo "It is part of Node.js 20 or later, see https://nodejs.org/ for installation instructions."
+	exit 0;
+fi
+
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
+SOURCE="$0"
+
+# Resolve $SOURCE until the file is no longer a symlink.
+while [ -h "$SOURCE" ]; do
+	DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+	SOURCE="$( readlink "$SOURCE" )"
+	# If $SOURCE was a relative symlink, we need to resolve it relative to the
+	# path where the symlink file was located.
+	case $SOURCE in
+		/*) ;;
+		*) SOURCE="$DIR/$SOURCE";;
+	esac
+done
+
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+# A project can override the shared ruleset by committing its own .gherkin-lintrc.
+CONFIG_FILE=".gherkin-lintrc"
+if [ ! -f "${CONFIG_FILE}" ]
+then
+	CONFIG_FILE="${WP_CLI_TESTS_ROOT}/.gherkin-lintrc"
+fi
+
+# Pinned so that a new release of the linter cannot turn a green build red
+# without a commit in this repository.
+GHERKIN_LINT_VERSION="${WP_CLI_TEST_GHERKIN_LINT_VERSION:-1.0.2}"
+
+# Without an explicit path the linter walks the whole working directory, vendor
+# included. The feature files are the target.
+if [ $# -eq 0 ]
+then
+	set -- features
+fi
+
+run_linter() {
+	npx --yes "gherkin-lint-plus@${GHERKIN_LINT_VERSION}" --config "${CONFIG_FILE}" "$@"
+}
+
+if [ -n "${NO_COLOR}" ]
+then
+	# The linter colors its report unconditionally: it honors neither NO_COLOR
+	# nor the absence of a terminal, and "stylish" is its only output format.
+	# It writes the report to STDERR, so strip the escape sequences from that
+	# stream while leaving STDOUT and the exit code alone.
+	STDERR_FILE=$( mktemp )
+
+	run_linter "$@" 2> "${STDERR_FILE}"
+	STATUS=$?
+
+	if [ -s "${STDERR_FILE}" ]
+	then
+		ESC=$( printf '\033' )
+		sed "s/${ESC}\[[0-9;]*m//g" "${STDERR_FILE}" >&2
+	fi
+
+	rm -f "${STDERR_FILE}"
+
+	exit ${STATUS};
+fi
+
+run_linter "$@"

--- a/bin/run-gherkin-lint-tests
+++ b/bin/run-gherkin-lint-tests
@@ -72,6 +72,7 @@ then
 	# It writes the report to STDERR, so strip the escape sequences from that
 	# stream while leaving STDOUT and the exit code alone.
 	STDERR_FILE=$( mktemp )
+	trap 'rm -f "${STDERR_FILE}"' EXIT HUP INT TERM
 
 	run_linter "$@" 2> "${STDERR_FILE}"
 	STATUS=$?
@@ -81,8 +82,6 @@ then
 		ESC=$( printf '\033' )
 		sed "s/${ESC}\[[0-9;]*m//g" "${STDERR_FILE}" >&2
 	fi
-
-	rm -f "${STDERR_FILE}"
 
 	exit ${STATUS};
 fi

--- a/bin/run-linter-tests
+++ b/bin/run-linter-tests
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-# Honor the NO_COLOR convention (https://no-color.org/) by leaving the color
-# decision to the tool's own TTY detection instead of forcing it.
+# Honor the NO_COLOR convention (https://no-color.org/). This has to turn the
+# color off explicitly rather than omit the flag, because the tool's own
+# detection only asks whether STDOUT is a terminal and knows nothing about
+# NO_COLOR, so an interactive run would still be colored.
 COLOR_ARGS="--colors"
 if [ -n "${NO_COLOR}" ]; then
-	COLOR_ARGS=""
+	COLOR_ARGS="--no-colors"
 fi
 
 # shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.

--- a/bin/run-linter-tests
+++ b/bin/run-linter-tests
@@ -1,3 +1,11 @@
 #!/bin/sh
 
-vendor/bin/parallel-lint -j 10 --colors --exclude vendor . "$@"
+# Honor the NO_COLOR convention (https://no-color.org/) by leaving the color
+# decision to the tool's own TTY detection instead of forcing it.
+COLOR_ARGS="--colors"
+if [ -n "${NO_COLOR}" ]; then
+	COLOR_ARGS=""
+fi
+
+# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.
+vendor/bin/parallel-lint -j 10 $COLOR_ARGS --exclude vendor . "$@"

--- a/bin/run-php-unit-tests
+++ b/bin/run-php-unit-tests
@@ -10,9 +10,19 @@ then
 		EXTRA_ARGS="--display-warnings --fail-on-warning --display-notices --fail-on-notice --display-deprecations --fail-on-deprecation"
 	fi
 
+	# Honor the NO_COLOR convention (https://no-color.org/). This has to be an
+	# explicit "never" rather than an omitted flag, because a project's
+	# phpunit.xml may well turn colors on by itself.
+	COLOR_ARGS="--color=always"
+	if [ -n "${NO_COLOR}" ]; then
+		COLOR_ARGS="--color=never"
+	fi
+
 	if [ -f "./vendor/wp-cli/wp-cli-tests/tests/bootstrap.php" ]; then
-		vendor/bin/phpunit --color=always "$@" $EXTRA_ARGS --bootstrap ./vendor/wp-cli/wp-cli-tests/tests/bootstrap.php
+		# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.
+		vendor/bin/phpunit $COLOR_ARGS "$@" $EXTRA_ARGS --bootstrap ./vendor/wp-cli/wp-cli-tests/tests/bootstrap.php
 	else
-		vendor/bin/phpunit --color=always "$@" $EXTRA_ARGS
+		# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.
+		vendor/bin/phpunit $COLOR_ARGS "$@" $EXTRA_ARGS
 	fi
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -3,5 +3,15 @@
 # Run the code style check only if a configuration file exists.
 if [ -f ".phpcs.xml" ] || [ -f "phpcs.xml" ] || [ -f ".phpcs.xml.dist" ] || [ -f "phpcs.xml.dist" ]
 then
-	vendor/bin/phpcs "$@"
+	EXTRA_ARGS=""
+
+	# Compact, one-line-per-violation output without the progress ticker.
+	# Useful for CI logs and for AI coding agents, which pay for every token of
+	# the report they read back.
+	if [ -n "${WP_CLI_TEST_QUIET}" ]; then
+		EXTRA_ARGS="-q --report=emacs"
+	fi
+
+	# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.
+	vendor/bin/phpcs $EXTRA_ARGS "$@"
 fi

--- a/bin/run-phpcs-tests
+++ b/bin/run-phpcs-tests
@@ -9,7 +9,16 @@ then
 	# Useful for CI logs and for AI coding agents, which pay for every token of
 	# the report they read back.
 	if [ -n "${WP_CLI_TEST_QUIET}" ]; then
-		EXTRA_ARGS="-q --report=emacs"
+		EXTRA_ARGS="-q"
+
+		# A report asked for on the command line wins. PHPCS does not let a
+		# later --report replace an earlier one -- 3.x prints both reports and
+		# 4.x keeps only the first it saw -- so the compact one has to stay out
+		# of the way rather than rely on ordering.
+		case " $* " in
+			*" --report="*|*" --report-"*) ;;
+			*) EXTRA_ARGS="${EXTRA_ARGS} --report=emacs" ;;
+		esac
 	fi
 
 	# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.

--- a/bin/run-phpstan-tests
+++ b/bin/run-phpstan-tests
@@ -1,7 +1,22 @@
 #!/bin/sh
 
-# Run the code style check only if a configuration file exists.
+# Run the static analysis only if a configuration file exists.
 if [ -f "phpstan.dist.neon" ] || [ -f "phpstan.neon.dist" ] || [ -f "phpstan.neon" ]
 then
-	vendor/bin/phpstan --memory-limit=2048M analyse "$@"
+	EXTRA_ARGS=""
+
+	# Honor the NO_COLOR convention (https://no-color.org/).
+	if [ -n "${NO_COLOR}" ]; then
+		EXTRA_ARGS="--no-ansi"
+	fi
+
+	# Replace the redrawing progress bar and the box-drawing result table with
+	# plain `file:line:message` lines. Useful for CI logs and for AI coding
+	# agents, which pay for every token of the report they read back.
+	if [ -n "${WP_CLI_TEST_QUIET}" ]; then
+		EXTRA_ARGS="${EXTRA_ARGS} --no-progress --error-format=raw"
+	fi
+
+	# shellcheck disable=SC2086 # Intentional word splitting of the optional arguments.
+	vendor/bin/phpstan --memory-limit=2048M analyse $EXTRA_ARGS "$@"
 fi

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "bin/install-package-tests",
         "bin/rerun-behat-tests",
         "bin/run-behat-tests",
+        "bin/run-gherkin-lint-tests",
         "bin/run-linter-tests",
         "bin/run-php-unit-tests",
         "bin/run-phpcs-tests",
@@ -89,6 +90,7 @@
         "behat": "run-behat-tests",
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
+        "lint-gherkin": "run-gherkin-lint-tests",
         "phpcs": "run-phpcs-tests",
         "phpcbf": "run-phpcbf-cleanup",
         "phpstan": "run-phpstan-tests",
@@ -96,6 +98,7 @@
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",
+            "@lint-gherkin",
             "@phpcs",
             "@phpstan",
             "@phpunit",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wp-cli-tests",
+	"description": "Pins the Node tooling used by the WP-CLI testing framework. Not published to npm.",
+	"private": true,
+	"license": "MIT",
+	"devDependencies": {
+		"gherkin-lint-plus": "1.0.2"
+	}
+}


### PR DESCRIPTION
Three independent changes coming out of the discussion in wp-cli/wp-cli#6161 about what it costs an AI agent — or anyone iterating in a terminal — to work in a WP-CLI repository. Happy to split them into separate pull requests if that reads better.

Pairs with wp-cli/.github#285, which rewrites the `composer test` guidance in `AGENTS.md` and points the CI Gherkin job at `composer lint-gherkin`.

## 1. Quieter output, opt-in

Two environment variables, both unset by default, so nothing changes for existing users or for CI:

- **`NO_COLOR`** ([no-color.org](https://no-color.org/)) stops the runners from forcing ANSI color on. `run-linter-tests` passed `--colors` and `run-php-unit-tests` passed `--color=always` unconditionally, so every captured log carried escape sequences whether or not anything was going to render them. Where a project's own config can turn color back on — `phpunit.xml` with `colors="true"` — the flag is set to an explicit `never` rather than omitted.
- **`WP_CLI_TEST_QUIET`** switches the reporters to their most compact form:
  - PHP_CodeSniffer → `-q --report=emacs`, one `file:line:col` line per violation, no progress ticker
  - PHPStan → `--no-progress --error-format=raw`, one `file:line:message` line per error, no redrawing progress bar and no box-drawing result table

  Behat is deliberately untouched: its `progress` output is already minimal, and its step definition snippets are how a typo in an existing step surfaces, so they are a diagnostic rather than noise.

Also documents, in the README, things the runners already supported but nobody had written down: narrowing a Behat run to a single scenario with `features/x.feature:12`, `--tags=`, `--stop-on-failure`, and `composer behat-rerun`.

## 2. Cache the WP_VERSION lookup

`run-behat-tests` resolved `WP_VERSION` over the network on every single invocation, whether you were running the full suite or re-running one scenario for the fifth time while iterating on a fix.

It also made two separate requests for what is one question. The `wp-versions` artifact already carries a status per release with the current one marked `latest`, so the extra call to `api.wordpress.org` was redundant. Both the `latest` resolution and the `X.Y` → latest-patch resolution now come out of that single file.

It is cached under the system temp directory, following the `wp-cli-test-*` naming the `FeatureContext` core download cache already uses. Lifetime defaults to a day and is configurable through `WP_CLI_TEST_WP_VERSION_CACHE_TTL`, where `0` fetches every run. Net effect: at most one request per run, and none at all on a warm cache.

Two behavior changes fall out of it, both of which look like improvements but are worth calling out explicitly:

- A run without connectivity now falls back to the last known copy. Previously it continued with an empty `WP_VERSION`, which silently disabled filtering of the `@require-wp-*` tags.
- When there is nothing to fall back to, that is now reported rather than being silent.

`WP_VERSION=X.Y.0` still normalizes to `X.Y` and stops there, rather than resolving on to the newest patch — that spelling asks for the initial release specifically.

## 3. Bring the Gherkin linting into the test suite

The feature files are linted on every pull request, but the check exists only inside the reusable CI workflow and its ruleset lives in `wp-cli/.github`. Contributors cannot run it locally at all — not "it is inconvenient", but there is no config file in the repository to run it against. So `composer test` passing does not mean the build passes, and the way to find out is to push.

This moves it next to the other suites:

- `.gherkin-lintrc` ships with this package as the shared default ruleset, carried over unchanged from `wp-cli/.github`. A project that needs different rules overrides it by committing its own.
- `composer lint-gherkin` runs it, and it joins `composer test` and the setup instructions.
- CI can then call that script instead of reimplementing the invocation, which leaves one place to change the rules.

Uses [gherkin-lint-plus](https://www.npmjs.com/package/gherkin-lint-plus). It is a Node package, so it runs through `npx` and needs Node.js 20 or later; where `npx` is absent it reports that it is skipping rather than failing a suite that is otherwise entirely PHP. That is a deliberate trade — a hard failure would break `composer test` for every PHP-only contributor across ~40 repositories — and CI, where Node is always present, still enforces it.

The version is pinned in a `package.json` that exists for no other purpose: it is private, has no scripts, and nothing runs `npm install` against it. The pin lives there rather than in the shell script because a version string in a shell script is invisible to Dependabot. Picking the updates up needs the npm entry added in wp-cli/.github#285.

One wrinkle worth recording: the linter writes its report to STDERR and colors it unconditionally, honoring neither `NO_COLOR` nor the absence of a terminal, and `stylish` is its only output format. So the runner strips the escape sequences from that stream itself when `NO_COLOR` is set, preserving STDOUT and the exit code.

## Testing

The Gherkin linting is verified end to end, since Node was available where I was working:

- Both this package's four feature files and `wp-cli/wp-cli`'s thirty-five pass cleanly under the ported ruleset, so adopting this does not start with a wall of pre-existing violations.
- Positive control on a deliberately broken feature file: `file-name`, `no-unnamed-scenarios`, `indentation` and `use-and` are all caught, exit code 1, while `no-trailing-spaces` correctly stays quiet because the shared config disables it. The fork reads the existing ruleset the same way `gherkin-lint` did, `indentation` option keys included.
- `NO_COLOR=1` output is stripped of escape sequences with the exit code preserved; the default run keeps its colors; a clean tree prints nothing and exits 0; an explicit path argument overrides the `features` default; a package with no `features` directory skips and exits 0; a `package.json` with the pin removed fails with a message rather than silently installing the latest release.

The version resolution was exercised against a stubbed `curl` and the real artifact: cold cache, warm cache with `curl` removed from `PATH` entirely (zero requests), stale entry with the network down, a malformed response, `latest` → `7.0.4`, `6.8` → `6.8.8`, `6.9.0` → `6.9`, `7.0.0` → `7.0`, and `trunk` and exact versions passing through untouched. All the shell is syntax-checked and `composer validate` passes.

What I could **not** do is run the PHP suites. `composer install` does not complete in the environment I am working in — `phpstan/phpstan` is dist-only and its dist URL is on `api.github.com`, which is blocked here. So the flags in the first commit (`--report=emacs`, `--error-format=raw`, `--color=never`) are unverified by execution and rest on the documented CLI surface of each tool. That is the part of this pull request that most needs CI, or a second pair of eyes.

Refs wp-cli/wp-cli#6161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Gherkin linting to the standard test workflow.
  - Added PHPStan analysis for PHP embedded in feature files.
  - Added configurable WordPress version metadata caching with offline fallback.
  - Added advanced Behat filtering and rerun options.

- **Improvements**
  - Added `NO_COLOR` support across test and lint commands.
  - Added quiet output controls for code-quality checks.

- **Documentation**
  - Documented linting, static analysis, test filtering, reruns, output controls, caching, and environment-specific scenario tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->