### PR TITLE
Add WP-Compat PHPStan extension configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=7.2.24",
         "behat/behat": "^v3.15.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || ^0.5 || ^0.6.2 || ^0.7.1 || ^1.0.0",
+        "johnbillion/wp-compat": "^2.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "^10.0",

--- a/extension.neon
+++ b/extension.neon
@@ -29,6 +29,10 @@ rules:
 parameters:
   dynamicConstantNames:
     - FOO
+  WPCompat:
+    pluginFile: null
+    # Oldest WordPress version supported by WP-CLI.
+    requiresAtLeast: '4.9'
   strictRules:
     allRules: false
     disallowedLooseComparison: false
@@ -53,9 +57,13 @@ parameters:
     dynamicCallOnStaticMethod: false
     illegalConstructorMethodCall: false
 
-# Add the schema from phpstan-strict-rules so it's available without loading the extension
-# and the above configuration works.
+# Add the schemas from phpstan-strict-rules and wp-compat so they're available without
+# loading the extensions and the above configuration works.
 parametersSchema:
+  WPCompat: structure([
+    pluginFile: schema(string(), nullable())
+    requiresAtLeast: schema(string(), nullable())
+  ])
   strictRules: structure([
     allRules: anyOf(bool(), arrayOf(bool())),
     disallowedLooseComparison: anyOf(bool(), arrayOf(bool())),


### PR DESCRIPTION
This PR integrates the WP-Compat PHPStan extension to enable WordPress compatibility checking in the codebase.

## Summary
Added configuration and schema definitions for the WP-Compat PHPStan extension to validate code compatibility with WordPress versions.

## Key Changes
- Added `johnbillion/wp-compat` dependency to composer.json
- Configured WP-Compat parameters in extension.neon:
  - Set `pluginFile` to null (default behavior)
  - Set `requiresAtLeast` to '4.9' (oldest supported WordPress version for WP-CLI)
- Added parametersSchema definition for WP-Compat to make the configuration available without explicitly loading the extension

## Implementation Details
The schema definition allows both `pluginFile` and `requiresAtLeast` to be nullable strings, providing flexibility in configuration while maintaining type safety through PHPStan's schema validation.

https://claude.ai/code/session_01NADf5amDBgJ4ZBbd2qgijy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WordPress compatibility checks for projects targeting WordPress 4.9 or later.
  * Added configuration options for specifying the plugin file and minimum supported WordPress version.
* **Documentation**
  * Updated configuration schema guidance to include the new compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->